### PR TITLE
Xfail test until we make a nightly job

### DIFF
--- a/tests/desktop/test_purchase_app.py
+++ b/tests/desktop/test_purchase_app.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 import pytest
 from unittestzero import Assert
 
@@ -14,7 +15,7 @@ class TestPurchaseApp:
 
     _app_name = 'Campy camperson'
 
-    @pytest.mark.xfail(reason="App purchase requers Nightly")
+    @pytest.mark.xfail(reason='App purchase requires Nightly')
     def test_that_purchases_an_app_without_pre_auth_and_requests_a_refund(self, mozwebqa):
         """Litmus 58166"""
         home_page = Home(mozwebqa)


### PR DESCRIPTION
The purchase button is disabled in ff 11

http://qa-selenium.mv.mozilla.com:8080/job/marketplace.dev/HTML_Report/debug/tests_desktop_test_purchase_app_TestPurchaseApp/test_that_purchases_an_app_without_pre_auth_and_requests_a_refund/screenshot.png
