### PR TITLE
instruction for running tests should include --destructive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+results/*

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ WebDriver does not need a Selenium Server or Grid to run so these examples bypas
 
 An example of running all tests without a Selenium Server:
 
-	py.test --driver=firefox --credentials=/credentials.yaml
+	py.test --driver=firefox --credentials=/credentials.yaml --destructive .
 	
 An example of running all of the tests in one file:
 


### PR DESCRIPTION
the baseurl provided in the mozwebqa.cfg is a dev machine, so
--destructive is appropriate
