### PR TITLE
make sure both add and remove preaproval test cases always work

### DIFF
--- a/pages/desktop/consumer_pages/account_settings.py
+++ b/pages/desktop/consumer_pages/account_settings.py
@@ -21,13 +21,15 @@ class AccountSettings(Base):
 
     def click_payment_menu(self):
         self.selenium.find_element(*self._payment_locator).click()
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_present(*self._payment_page_locator))
+        self.wait_for_page_loaded()
         return Payments(self.testsetup)
 
     @property
     def header_title(self):
         return self.selenium.find_element(*self._header_title_locator).text
 
+    def wait_for_page_loaded(self):
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_present(*self._payment_page_locator))
 
 class BasicInfo(AccountSettings):
     """

--- a/pages/desktop/paypal/paypal_sandbox.py
+++ b/pages/desktop/paypal/paypal_sandbox.py
@@ -63,4 +63,6 @@ class PayPalSandbox(Page):
         self.selenium.find_element(*self._approve_button_locator).click()
         self.wait_for_progress_meter_to_load()
         from pages.desktop.consumer_pages.account_settings import Payments
-        return Payments(self.testsetup) #redirect
+        payments_page = Payments(self.testsetup) #redirect
+        payments_page.wait_for_page_loaded()
+        return payments_page

--- a/tests/desktop/test_users_account.py
+++ b/tests/desktop/test_users_account.py
@@ -25,6 +25,68 @@ class TestAccounts:
         home_page.footer.click_logout()
         Assert.false(home_page.footer.is_user_logged_in)
 
+    def test_that_user_can_set_up_pre_approval_on_payment_settings_page(self, mozwebqa):
+        """
+        Test for Litmus 58172.
+        https://litmus.mozilla.org/show_test.cgi?id=58172
+        """
+
+        # We have to first log in to PayPal developer to access the PayPal sandbox
+        self._developer_page_login_to_paypal(mozwebqa)
+
+        # get to payment settings page as 'add_preapproval' user
+        payment_settings_page = self._payment_settings_page_as_user(mozwebqa, 'add_preapproval')
+
+        try:
+            # set up non-pre-approval precondition
+            if payment_settings_page.is_remove_pre_approval_button_visible:
+                payment_settings_page.click_remove_pre_approval()
+                Assert.false(payment_settings_page.is_remove_pre_approval_button_visible)
+
+            # do test
+            payment_settings_page = self._set_up_pre_approval(payment_settings_page)
+
+            # verify
+            Assert.true(payment_settings_page.is_pre_approval_enabled)
+            Assert.true(payment_settings_page.is_success_message_visible)
+
+        finally:
+            # clean up
+            if payment_settings_page.is_remove_pre_approval_button_visible:
+                payment_settings_page.click_remove_pre_approval()
+            Assert.false(payment_settings_page.is_remove_pre_approval_button_visible)
+
+    def test_that_user_can_remove_prepapproval_on_payment_settings_page(self, mozwebqa):
+        # We have to first login to PayPal developer to access the PayPal sandbox
+        self._developer_page_login_to_paypal(mozwebqa)
+
+        # get to payment settings page as 'remove_preapproval' user
+        payment_settings_page = self._payment_settings_page_as_user(mozwebqa, 'remove_preapproval')
+
+        try:
+            # set up pre-approval precondition
+            if not payment_settings_page.is_pre_approval_enabled:
+                payment_settings_page = self._set_up_pre_approval(payment_settings_page)
+                Assert.true(payment_settings_page.is_remove_pre_approval_button_visible,
+                    "Remove pre-approval button is not available. Pre-approval might be off")
+
+            # do test
+            payment_settings_page.click_remove_pre_approval()
+
+            # verify
+            Assert.false(payment_settings_page.is_remove_pre_approval_button_visible,
+                "Remove pre-approval button is visible after click_remove_pre_approval")
+            Assert.false(payment_settings_page.is_pre_approval_enabled, 
+                "Pre-approval is still enabled")
+            Assert.true(payment_settings_page.is_success_message_visible, 
+                "Success message is not visible")
+
+        finally:
+            # restore the account to the initial state
+            payment_settings_page = self._set_up_pre_approval(payment_settings_page)
+            Assert.true(payment_settings_page.is_pre_approval_enabled)
+            Assert.true(payment_settings_page.is_success_message_visible)
+
     def _developer_page_login_to_paypal(self, mozwebqa):
         developer_paypal_page = PayPal(mozwebqa)
         developer_paypal_page.go_to_page()
@@ -61,66 +123,3 @@ class TestAccounts:
         payment_settings_page = paypal_sandbox.click_approve_button()
 
         return payment_settings_page
-
-    def test_that_user_can_set_up_pre_approval_on_payment_settings_page(self, mozwebqa):
-        """
-        Test for Litmus 58172.
-        https://litmus.mozilla.org/show_test.cgi?id=58172
-        """
-
-        # We have to first log in to PayPal developer to access the PayPal sandbox
-        developer_paypal_page = self._developer_page_login_to_paypal(mozwebqa)
-
-        # get to payment settings page as 'add_preapproval' user
-        payment_settings_page = self._payment_settings_page_as_user(mozwebqa, 'add_preapproval')
-
-        try:
-            # set up non-pre-approval precondition
-            if payment_settings_page.is_remove_pre_approval_button_visible:
-                payment_settings_page.click_remove_pre_approval()
-                Assert.false(payment_settings_page.is_remove_pre_approval_button_visible)
-
-            # do test
-            payment_settings_page = self._set_up_pre_approval(payment_settings_page)
-
-            # verify
-            Assert.true(payment_settings_page.is_pre_approval_enabled)
-            Assert.true(payment_settings_page.is_success_message_visible)
-
-        finally:
-            # clean up
-            if payment_settings_page.is_remove_pre_approval_button_visible:
-                payment_settings_page.click_remove_pre_approval()
-            Assert.false(payment_settings_page.is_remove_pre_approval_button_visible)
-
-    def test_that_user_can_remove_prepapproval_on_payment_settings_page(self, mozwebqa):
-        # We have to first login to PayPal developer to access the PayPal sandbox
-        developer_paypal_page = self._developer_page_login_to_paypal(mozwebqa)
-
-        # get to payment settings page as 'remove_preapproval' user
-        payment_settings_page = self._payment_settings_page_as_user(mozwebqa, 'remove_preapproval')
-
-
-        try:
-            # set up pre-approval precondition
-            if not payment_settings_page.is_pre_approval_enabled:
-                payment_settings_page = self._set_up_pre_approval(payment_settings_page)
-                Assert.true(payment_settings_page.is_remove_pre_approval_button_visible, 
-                    "Remove pre-approval button is not available. Pre-approval might be off")
-
-            # do test
-            payment_settings_page.click_remove_pre_approval()
-
-            # verify
-            Assert.false(payment_settings_page.is_remove_pre_approval_button_visible, 
-                "Remove pre-approval button is visible after click_remove_pre_approval")
-            Assert.false(payment_settings_page.is_pre_approval_enabled, 
-                "Pre-approval is still enabled")
-            Assert.true(payment_settings_page.is_success_message_visible, 
-                "Success message is not visible")
-
-        finally:
-            # restore the account to the initial state
-            payment_settings_page = self._set_up_pre_approval(payment_settings_page)
-            Assert.true(payment_settings_page.is_pre_approval_enabled)
-            Assert.true(payment_settings_page.is_success_message_visible)


### PR DESCRIPTION
refactor out code common to the two test cases.

some Asserts were removed as duplicates of the WebDriverWait that
preceded them in the page code.

except Exception was removed because it was not required and was not
doing anything additional.

PayPalSandbox.login_paypal_sandbox can click_login_tab itself
PayPalSandbox.click_approve_button returns Payments page, to reflect
redirect
