### PR TITLE
Fixes to get test_that_purchases_an_app_without_pre_auth_and_requests_a_refund to run

### DIFF
--- a/pages/desktop/paypal/paypal_popup.py
+++ b/pages/desktop/paypal/paypal_popup.py
@@ -14,7 +14,7 @@ class PayPalPopup(Page):
     _pop_up_id = '_popupFlow'
     _email_locator = (By.ID, 'email')
     _password_locator = (By.ID, 'password')
-    _login_locator = (By.CSS_SELECTOR, 'p.buttons > input')
+    _login_locator = (By.CSS_SELECTOR, 'input#login')
     _log_out_locator = (By.ID, 'logOutLink')
 
     _pay_button_locator = (By.NAME, '_eventId_submit')

--- a/tests/desktop/test_purchase_app.py
+++ b/tests/desktop/test_purchase_app.py
@@ -20,7 +20,7 @@ class TestPurchaseApp:
         home_page = Home(mozwebqa)
 
         home_page.go_to_homepage()
-        home_page.login()
+        home_page.login(user="buy_no_preapproval")
 
         Assert.true(home_page.is_the_current_page)
 


### PR DESCRIPTION
This test was failing on my machine, and also apparently on Jenkins. I found a couple of problems that were causing the test to fail early, which I've fixed. The test is still failing on the second to last assert, as it is expecting a refund to be successful, but the refund is failing. This seems like a business logic issue rather than a test issue.
