### PR TITLE
Added test that checks expanding of app description

### DIFF
--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -136,7 +136,7 @@ class Details(Base):
     @property
     def is_app_description_expanded(self):
         return self.is_element_visible(*self._collapse_description_locator)
-            
+
     def expand_app_description(self):
         self.selenium.find_element(*self._expand_description_locator).click()
 

--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -70,11 +70,11 @@ class TestDetailsPage:
         Assert.true(details_page.is_published_date_visible)
 
     @pytest.mark.nondestructive
-    def test_that_checks_expanding_of_app_description(self, mozwebqa):
+    def test_that_checks_expanding_and_collapsing_of_app_description(self, mozwebqa):
         """Test for https://www.pivotaltracker.com/story/show/33702677"""
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        
+
         search_page = home_page.header.search('checkers')
         details_page = search_page.results[0].click_name()
         details_page.expand_app_description()
@@ -82,15 +82,6 @@ class TestDetailsPage:
         Assert.true(details_page.is_app_description_expanded)
         Assert.greater(len(details_page.app_expanded_description_text), 0)
 
-    @pytest.mark.nondestructive
-    def test_that_checks_collapsing_of_app_description(self, mozwebqa):
-        """Test for https://www.pivotaltracker.com/story/show/33702677"""
-        home_page = Home(mozwebqa)
-        home_page.go_to_homepage()
-        
-        search_page = home_page.header.search('checkers')
-        details_page = search_page.results[0].click_name()
-        details_page.expand_app_description()
         details_page.collapse_app_description()
 
         Assert.false(details_page.is_app_description_expanded)


### PR DESCRIPTION
Pivotal task is https://www.pivotaltracker.com/story/show/33702677

Uh, there are two things. I didn't find any method for selecting app from home page or from any other page, so I added quite simple one to home.py that picks first app from featured section on home page. I suppose it's good for now. Another thing is that for some apps there can be no expanded description and hence test will fail.

would love to hear any suggestions.
