### PR TITLE
Pivotal 33702407

### DIFF
--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -189,10 +189,8 @@ class TestSearching:
         home_page.go_to_homepage()
         
         foreign_search_term = 'döda papegojan'.decode('utf-8')
-        
         search_page = home_page.header.search(foreign_search_term)
-        displayed_search_term = search_page.title.split('"')[1]
 
-        Assert.equal(search_page._page_title, search_page.page_title)
-        Assert.equal(foreign_search_term, displayed_search_term)
+        Assert.true(search_page.is_the_current_page)
+        Assert.contains(foreign_search_term, search_page.title)
         Assert.equal(foreign_search_term, search_page.breadcrumbs[2].text)


### PR DESCRIPTION
Test for search with unicode characters. 
Firstly I wanted to use Cyrillic, but there was some webdriver problem with typing Cyrillic letters (uppercase instead of lowercase), so I used Swedish.

Note: Maybe it's better to use Assert.contains() instead of title splitting.
