### PR TITLE
Changed workflow of edit app validation test

### DIFF
--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -148,6 +148,7 @@ class EditListing(Base):
         _device_types_error_locator = (By.CSS_SELECTOR, '#addon-device-types-edit > ul.errorlist > li')
         _save_changes_locator = (By.CSS_SELECTOR, 'div.listing-footer > button')
         _loading_locator = (By.CSS_SELECTOR, 'div.item.island.loading')
+        _cancel_link_locator = (By.CSS_SELECTOR, 'div.listing-footer > a')
 
         @property
         def is_this_form_open(self):
@@ -250,6 +251,9 @@ class EditListing(Base):
             WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
                 and self.selenium.execute_script('return jQuery.active == 0'))
 
+        def click_cancel(self):
+            self.selenium.find_element(*self._cancel_link_locator).click()
+
 
     class SupportInformationRegion(Page):
 
@@ -328,7 +332,6 @@ class EditListing(Base):
             self.selenium.find_element(*self._save_changes_locator).click()
             WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
                 and self.selenium.execute_script('return jQuery.active == 0'))
-
 
         def click_cancel(self):
             self.selenium.find_element(*self._cancel_link_locator).click()

--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -222,41 +222,46 @@ class TestDeveloperHub(BaseTest):
 
         # bring up the basic info form for the first free app
         edit_listing = my_apps.first_free_app.click_edit()
-        basic_info_region = edit_listing.click_edit_basic_info()
 
         # check name validation
+        basic_info_region = edit_listing.click_edit_basic_info()
         basic_info_region.type_name('')
         basic_info_region.click_save_changes()
         Assert.true(basic_info_region.is_this_form_open)
         Assert.contains('This field is required.', basic_info_region.name_error_message)
-        basic_info_region.type_name('something')
+        basic_info_region.click_cancel()
 
         # check App URL validation
+        basic_info_region = edit_listing.click_edit_basic_info()
         basic_info_region.type_url_end('')
         basic_info_region.click_save_changes()
         Assert.true(basic_info_region.is_this_form_open)
         Assert.contains('This field is required.', basic_info_region.url_end_error_message)
-        basic_info_region.type_url_end('something')
+        basic_info_region.click_cancel()
 
         # check Summary validation
+        basic_info_region = edit_listing.click_edit_basic_info()
         basic_info_region.type_summary('')
         basic_info_region.click_save_changes()
         Assert.true(basic_info_region.is_this_form_open)
         Assert.contains('This field is required.', basic_info_region.summary_error_message)
-        basic_info_region.type_summary('something')
+        basic_info_region.click_cancel()
 
         # check Categories validation
+        basic_info_region = edit_listing.click_edit_basic_info()
         basic_info_region.clear_categories()
         basic_info_region.click_save_changes()
         Assert.true(basic_info_region.is_this_form_open)
         Assert.contains('This field is required.', basic_info_region.categories_error_message)
-        basic_info_region.select_categories('Music', True)
+        basic_info_region.click_cancel()
 
         # check Device Types
+        basic_info_region = edit_listing.click_edit_basic_info()
         basic_info_region.clear_device_types()
         basic_info_region.click_save_changes()
         Assert.true(basic_info_region.is_this_form_open)
         Assert.contains('This field is required.', basic_info_region.device_types_error_message)
+        basic_info_region.click_cancel()
 
     def test_that_a_screenshot_can_be_added(self, mozwebqa):
         """Test the happy path for adding a screenshot for a free submitted app.


### PR DESCRIPTION
I have changed the workflow of this test to cancel and reopen the edit form.

Previously entering the string 'something' into the field caused a unique value validation failure.

Now cancelling the save instead resets the value and the form to its initial state.

I've retained the test's destructive status incase the cancel or app fails at some point.
