### PR TITLE
Xfailed TestDeveloperHub.test_hosted_app_submission

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -16,6 +16,7 @@ from tests.desktop.base_test import BaseTest
 
 class TestDeveloperHub(BaseTest):
 
+    @pytest.mark.xfail(reason='')
     def test_hosted_app_submission(self, mozwebqa):
 
         app = MockApplication()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=801667
 The app manifest URL for a hosted app submission is taking too long to validate
