### PR TITLE
Fix for TestDeveloperHub.test_that_checks_that_manifest_url_cannot_be_ed...

### DIFF
--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -243,8 +243,9 @@ class EditListing(Base):
             else:
                 self.type_in_element(self._summary_after_failure_locator, text)
 
-        def type_manifest_url(self, text):
-            self.type_in_element(self._manifest_url_locator, text)
+        @property
+        def is_manifest_url_editable(self):
+            return self.is_element_present(*self._manifest_url_locator)
 
         def click_save_changes(self):
             self.selenium.find_element(*self._save_changes_locator).click()

--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -226,18 +226,15 @@ class TestDeveloperHub(BaseTest):
 
         Litmus link: https://litmus.mozilla.org/show_test.cgi?id=50478
         """
-        with pytest.raises(NoSuchElementException):
-            dev_home = Home(mozwebqa)
-            dev_home.go_to_developers_homepage()
-            dev_home.login(user="default")
-            my_apps = dev_home.header.click_my_submissions()
+        dev_home = Home(mozwebqa)
+        dev_home.go_to_developers_homepage()
+        dev_home.login(user="default")
+        my_apps = dev_home.header.click_my_submissions()
 
-            # bring up the basic info form for the first free app
-            edit_listing = my_apps.first_free_app.click_edit()
-            basic_info_region = edit_listing.click_edit_basic_info()
-            # Attempting to type into the manifest_url input should raise an
-            # NoSuchElementException.
-            basic_info_region.type_manifest_url('any value should cause an exception')
+        # bring up the basic info form for the first free app
+        edit_listing = my_apps.first_free_app.click_edit()
+        basic_info_region = edit_listing.click_edit_basic_info()
+        Assert.false(basic_info_region.is_manifest_url_editable)
 
     def test_that_checks_that_summary_must_be_limited_to_250_chars_on_basic_info_for_a_free_app(self, mozwebqa):
         """Ensure that the summary field cannot contain over 250 characters.


### PR DESCRIPTION
...ited_via_basic_info_for_a_free_app

The test is trying to type into an input field (_manifest_url_locator) and
if the type succeeds the test fails because it means that the field is the
manifest url is editable.
So, if '#manifest-url > td > input' is not found, NoSuchElementException is thrown,
hence the test passes.
