### PR TITLE
Fix first_free_app method that was causing the developer pages tests to ...

### DIFF
--- a/pages/desktop/developer_hub/developer_submissions.py
+++ b/pages/desktop/developer_hub/developer_submissions.py
@@ -48,7 +48,7 @@ class DeveloperSubmissions(Base):
                 if app.has_price and app.price == 'FREE':
                     return app
             if self.paginator.is_paginator_present:
-                if not self.paginator.is_first_page_disabled:
+                if not self.paginator.is_next_page_disabled:
                     self.paginator.click_next_page()
         else:
             raise Exception('App not found')


### PR DESCRIPTION
...fail.

The problem was that self.paginator.click_next_page() never happened.
