### PR TITLE
Remove check for input blank name fron test_developers_hub::test_that_checks_required_field_validations_on_basic_info_for_a_free_app

### DIFF
--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -131,15 +131,12 @@ class EditListing(Base):
         The form that becomes active when editing basic information for an application listing.
 
         """
-        _name_initial_locator = (By.CSS_SELECTOR, "#trans-name input[lang='en-us']")
-        _name_after_failure_locator = (By.CSS_SELECTOR, '#trans-name .unsaved')
         _url_end_locator = (By.ID, 'id_slug')
         _manifest_url_locator = (By.CSS_SELECTOR, '#manifest-url > td > input[readonly]')
         _summary_initial_locator = (By.CSS_SELECTOR, '#trans-summary [name="summary_en-us"]')
         _summary_after_failure_locator = (By.CSS_SELECTOR, '#trans-summary .unsaved')
         _summary_char_count_locator = (By.CSS_SELECTOR, 'div.char-count')
         _categories_locator = (By.CSS_SELECTOR, 'ul.addon-categories > li')
-        _name_error_locator = (By.CSS_SELECTOR, '#trans-name + ul.errorlist > li')
         _summary_error_locator = (By.CSS_SELECTOR, '#trans-summary + ul.errorlist > li')
         _url_end_error_locator = (By.CSS_SELECTOR, '#slug_edit ul.errorlist > li')
         _categories_error_locator = (By.CSS_SELECTOR, 'div.addon-app-cats > ul.errorlist > li')
@@ -157,11 +154,6 @@ class EditListing(Base):
             """Return whether the character count for the summary field is reported as ok or not."""
             char_count = self.selenium.find_element(*self._summary_char_count_locator)
             return 'error' not in char_count.get_attribute('class')
-
-        @property
-        def name_error_message(self):
-            """Return the error message displayed for the name."""
-            return self.selenium.find_element(*self._name_error_locator).text
 
         @property
         def url_end_error_message(self):
@@ -198,12 +190,6 @@ class EditListing(Base):
                 device_type_checkbox = CheckBox(self.testsetup, device)
                 if device_type_checkbox.state == True:
                     device_type_checkbox.change_state()
-
-        def type_name(self, text):
-            if self.is_element_visible(*self._name_initial_locator):
-                self.type_in_element(self._name_initial_locator, text)
-            else:
-                self.type_in_element(self._name_after_failure_locator, text)
 
         def type_url_end(self, text):
             self.type_in_element(self._url_end_locator, text)

--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -271,14 +271,6 @@ class TestDeveloperHub(BaseTest):
         # bring up the basic info form for the first free app
         edit_listing = my_apps.first_free_app.click_edit()
 
-        # check name validation
-        basic_info_region = edit_listing.click_edit_basic_info()
-        basic_info_region.type_name('')
-        basic_info_region.click_save_changes()
-        Assert.true(basic_info_region.is_this_form_open)
-        Assert.contains('This field is required.', basic_info_region.name_error_message)
-        basic_info_region.click_cancel()
-
         # check App URL validation
         basic_info_region = edit_listing.click_edit_basic_info()
         basic_info_region.type_url_end('')


### PR DESCRIPTION
Now the name of the app can only be edited by updating the manifest.
