### PR TITLE
Replace twitter app, with Evernote app

### DIFF
--- a/tests/desktop/consumer_pages/test_details_page.py
+++ b/tests/desktop/consumer_pages/test_details_page.py
@@ -64,7 +64,7 @@ class TestDetailsPage:
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        search_page = home_page.header.search('twitter')
+        search_page = home_page.header.search('Evernote')
         details_page = search_page.results[0].click_name()
         details_page.expand_or_collapse_app_description()
 


### PR DESCRIPTION
Twitter app(aka TwitDeck) no longer has a "more..." expanding description
