### PR TITLE
Fix for failing test_that_checks_required_field_validations_on_device_ty...

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -295,14 +295,14 @@ class TestDeveloperHub(BaseTest):
         Assert.contains('This field is required.', basic_info_region.categories_error_message)
         basic_info_region.click_cancel()
 
-    def test_that_checks_required_field_validations_on_device_types(self, mozwebqa):
+    def test_that_checks_required_field_validations_on_device_types_for_hosted_apps(self, mozwebqa):
         dev_home = Home(mozwebqa)
         dev_home.go_to_developers_homepage()
         dev_home.login(user="default")
         my_apps = dev_home.header.click_my_submissions()
 
         # bring up the compatibility form for the first free app
-        compatibility_page = my_apps.first_free_app.click_compatibility_and_payments()
+        compatibility_page = my_apps.first_free_hosted_app.click_compatibility_and_payments()
         compatibility_page.clear_device_types()
         compatibility_page.click_save_changes()
         Assert.contains('Please select a device.', compatibility_page.device_types_error_message)


### PR DESCRIPTION
...pe

I talked to the devs on irc and packaged app are only supported for Firefox OS
and the device type can't be changed for now.
