### PR TITLE
saving language change in account settings

### DIFF
--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -86,6 +86,7 @@ class TestAccounts(BaseTest):
                             profile_page.save_button_text]
 
         profile_page.edit_language(language)
+        profile_page.save_changes()
 
         after_lang_change = [profile_page.get_url_current_page(),
                             profile_page.page_title,


### PR DESCRIPTION
The work flow has changed, we have to click the save button for the language to change.
