### PR TITLE
Fix for test_that_checks_apps_are_sorted_by_date

### DIFF
--- a/pages/desktop/developer_hub/developer_submissions.py
+++ b/pages/desktop/developer_hub/developer_submissions.py
@@ -109,6 +109,7 @@ class App(PageRegion):
     _packaged_app_locator = (By.CSS_SELECTOR, '.item-current-version')
     _manage_status_and_version_locator = (By.CSS_SELECTOR, 'a.status-link')
     _compatibility_and_payments_locator = (By.CSS_SELECTOR, 'div.item-actions > ul li a[href$="/payments/"]')
+    _date_locator = (By.CLASS_NAME, 'date-created')
 
     def _is_element_present_in_app(self, *locator):
         self.selenium.implicitly_wait(0)
@@ -147,6 +148,10 @@ class App(PageRegion):
     @property
     def has_price(self):
         return self._is_element_present_in_app(*self._price_locator)
+
+    @property
+    def has_date(self):
+        return self._is_element_present_in_app(*self._date_locator)
 
     def click_edit(self):
         self.find_element(*self._edit_link_locator).click()

--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -408,6 +408,7 @@ class TestDeveloperHub(BaseTest):
         pages_to_test = 10 if dev_submissions.paginator.total_page_number >= 10 else dev_submissions.paginator.total_page_number
         for i in range(1, pages_to_test):
             for app in dev_submissions.submitted_apps:
-                Assert.greater_equal(previous_app_date, app.date, 'Apps are not sorted ascending. According to Created date.')
-                previous_app_date = app.date
+                if app.has_date:
+                    Assert.greater_equal(previous_app_date, app.date, 'Apps are not sorted ascending. According to Created date.')
+                    previous_app_date = app.date
             dev_submissions.paginator.click_next_page()


### PR DESCRIPTION
Added check for date field inside app, because of bug https://bugzilla.mozilla.org/show_bug.cgi?id=842554, there are incomplete apps created and the test fails.
