### PR TITLE
A workaround for test_search

### DIFF
--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -27,6 +27,10 @@ class Base(Page):
         WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_balloon_locator)
                                                          and self.selenium.execute_script('return jQuery.active == 0'))
 
+    @property
+    def scroll_down(self):
+        self.selenium.execute_script('window.scrollTo(0,100);')
+
     def scroll_to_element(self, *locator):
         """Scroll to element"""
         el = self.selenium.find_element(*locator)

--- a/tests/mobile/test_search.py
+++ b/tests/mobile/test_search.py
@@ -20,6 +20,8 @@ class TestSearch():
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
+        home_page.scroll_down# a workaround, the "Search" field will appear only if we scroll
+
         search_page = home_page.search_for("")
 
         Assert.greater(len(search_page.results), 0)
@@ -28,6 +30,8 @@ class TestSearch():
     def test_that_searching_returns_results(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
+
+        home_page.scroll_down# a workaround, the "Search" field will appear only if we scroll
 
         search_page = home_page.search_for(self.search_term)
 
@@ -40,8 +44,9 @@ class TestSearch():
     def test_that_verifies_the_search_suggestions_list_under_the_search_field(self, mozwebqa):
 
         home_page = Home(mozwebqa)
-
         home_page.go_to_homepage()
+
+        home_page.scroll_down# a workaround, the "Search" field will appear only if we scroll
 
         home_page.header.click_search()
         Assert.true(home_page.header.is_search_visible)
@@ -66,6 +71,8 @@ class TestSearch():
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
+        home_page.scroll_down# a workaround, the "Search" field will appear only if we scroll
+
         search_page = home_page.search_for(self.search_term_with_no_result)
 
-        Assert.equal('No results found.', search_page.no_results_text)
+        Assert.equal('No results found', search_page.no_results_text)


### PR DESCRIPTION
This is a workaround for search field to appear, because now it only is visible only if we scroll a little
