### PR TITLE
Fix for test_user_can_login_and_logout for mobile

### DIFF
--- a/pages/mobile/settings.py
+++ b/pages/mobile/settings.py
@@ -41,6 +41,10 @@ class Account(Settings):
         return self.Apps
 
     @property
+    def is_sign_in_visible(self):
+        return self.is_element_visible(*self._login_locator)
+
+    @property
     def selected_settings_option(self):
         return self.selenium.find_element(*self._selected_option_locator).text
 

--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -17,17 +17,15 @@ class TestAccounts():
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        home_page.login_with_user(user="default")
-        Assert.false(home_page.header.is_account_settings_visible)
-        Assert.true(home_page.is_featured_section_visible)
-
         settings_page = home_page.header.click_settings()
+        settings_page.login()
 
         Assert.equal(settings_page.email_text, mozwebqa.credentials["default"]["email"])
 
         home_page = settings_page.click_logout()
         home_page.wait_for_ajax_on_page_finish()
-        Assert.true(home_page.header.is_login_visible)
+        home_page.header.click_settings()
+        Assert.true(settings_page.is_sign_in_visible)
 
     @pytest.mark.nondestructive
     def test_user_can_click_back_from_settings_page(self, mozwebqa):


### PR DESCRIPTION
This should be merged after https://github.com/mozilla/marketplace-tests/pull/233
