### PR TITLE
Settings button locator

### DIFF
--- a/pages/desktop/developer_hub/base.py
+++ b/pages/desktop/developer_hub/base.py
@@ -10,9 +10,10 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 from pages.page import Page
 
+
 class Base(Page):
 
-    def login(self, user = "default"):
+    def login(self, user="default"):
 
         self.header.click_login()
 
@@ -32,7 +33,7 @@ class Base(Page):
         _login_locator = (By.CSS_SELECTOR, 'a.browserid')
 
         #LoggedIn
-        _account_menu_locator = (By.CSS_SELECTOR, '.settings.sticky')
+        _account_menu_locator = (By.CSS_SELECTOR, '.header-button.icon.settings')
         _logout_locator = (By.CSS_SELECTOR, '.logout')
         _my_submissions_locator = (By.CSS_SELECTOR, '.account-links > ul > li:nth-of-type(2) > a')
 


### PR DESCRIPTION
The builds on Jenkins are ABORTED because the <code>login</code> method was waiting for settings button to be visible.
