### PR TITLE
Added click on notification

### DIFF
--- a/pages/mobile/settings.py
+++ b/pages/mobile/settings.py
@@ -35,6 +35,9 @@ class Account(Settings):
     def email_text(self):
         return self.selenium.find_element(*self._email_locator).get_attribute("value")
 
+    def click_on_notification(self):
+        self.selenium.find_element(*self._notification_locator).click()
+
     def click_logout(self):
         self.scroll_to_element(*self._logout_locator)
         self.selenium.find_element(*self._logout_locator).click()

--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -22,6 +22,7 @@ class TestAccounts():
 
         Assert.equal(settings_page.email_text, mozwebqa.credentials["default"]["email"])
 
+        settings_page.click_on_notification()
         settings_page.click_logout()
         Assert.true(settings_page.is_sign_in_visible)
 


### PR DESCRIPTION
This test fails on Saucelabs. But it passes for me locally. Added this method because I think the "Sign out" button is covered by the notification message and the test is to quick clicking on the button.
