### PR TITLE
Removing "wait_for_ajax_to_finish"

### DIFF
--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -14,18 +14,19 @@ from mocks.mock_user import MockUser
 
 class Base(Page):
 
-    _loading_balloon_locator = (By.CSS_SELECTOR, '.loading-fragment.overlay.active')
     _login_locator = (By.CSS_SELECTOR, '.header-button.persona')
     _persona_loading_balloon_locator = (By.CSS_SELECTOR, '.persona.loading-submit')
+    _load_home_page_balloon_locator = (By.CSS_SELECTOR, '.throbber')
+    _load_page_details_baloon_locator = (By.CSS_SELECTOR, '.spinner.spaced.alt')
 
     @property
     def page_title(self):
         WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
         return self.selenium.title
 
-    def wait_for_ajax_on_page_finish(self):
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_balloon_locator)
-                                                         and self.selenium.execute_script('return jQuery.active == 0'))
+    def wait_for_page_to_load(self):
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._load_page_details_baloon_locator)
+                                                         and not self.is_element_visible(*self._load_home_page_balloon_locator))
 
     def scroll_to_element(self, *locator):
         """Scroll to element"""

--- a/pages/desktop/consumer_pages/category.py
+++ b/pages/desktop/consumer_pages/category.py
@@ -20,7 +20,7 @@ class Category(Base):
     def __init__(self, testsetup, category_name):
         Base.__init__(self, testsetup)
         self._page_title = "%s | %s" % (category_name, self._page_title)
-        self.wait_for_ajax_on_page_finish()
+        self.wait_for_page_to_load()
 
     @property
     def title(self):

--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -38,7 +38,7 @@ class Details(Base):
 
     def __init__(self, testsetup, app_name=False):
         Base.__init__(self, testsetup)
-        self.wait_for_ajax_on_page_finish()
+        self.wait_for_page_to_load()
         if app_name:
             self._page_title = "%s | Firefox Marketplace" % app_name
             self.app_name = app_name

--- a/pages/desktop/consumer_pages/reviews.py
+++ b/pages/desktop/consumer_pages/reviews.py
@@ -21,7 +21,7 @@ class Reviews(Base):
 
     def __init__(self, testsetup, app_name=False):
         Base.__init__(self, testsetup)
-        self.wait_for_ajax_on_page_finish()
+        self.wait_for_page_to_load()
         if app_name:
             self._page_title = "Reviews for %s | Firefox Marketplace" % app_name
 
@@ -64,7 +64,7 @@ class Reviews(Base):
 
         def delete(self):
             self._root_element.find_element(*self._delete_review_locator).click()
-            self.wait_for_ajax_on_page_finish()
+            self.wait_for_page_to_load()
 
         @property
         def is_review_visible(self):

--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -14,7 +14,8 @@ from unittestzero import Assert
 
 class Base(Page):
 
-    _loading_balloon_locator = (By.CSS_SELECTOR, '.spinner')
+    _load_home_page_balloon_locator = (By.CSS_SELECTOR, '.throbber')
+    _load_page_details_baloon_locator = (By.CSS_SELECTOR, '.spinner.spaced.alt')
     _body_class_locator = (By.CSS_SELECTOR, '#container > #page')
 
     @property
@@ -22,9 +23,9 @@ class Base(Page):
         WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
         return self.selenium.title
 
-    def wait_for_ajax_on_page_finish(self):
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_balloon_locator)
-                                                         and self.selenium.execute_script('return jQuery.active == 0'))
+    def wait_for_page_to_load(self):
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._load_page_details_baloon_locator)
+                                                         and not self.is_element_visible(*self._load_home_page_balloon_locator))
 
     def scroll_to_element(self, *locator):
         """Scroll to element"""
@@ -38,7 +39,7 @@ class Base(Page):
         Assert.true(self.header.is_search_visible)
         self.header.type_in_search_field(search_term)
         self.header.submit_search()
-        self.wait_for_ajax_on_page_finish()
+        self.wait_for_page_to_load()
         from pages.mobile.search import Search
         return Search(self.testsetup)
 

--- a/tests/desktop/consumer_pages/test_reviews.py
+++ b/tests/desktop/consumer_pages/test_reviews.py
@@ -11,8 +11,6 @@ from persona_test_user import PersonaTestUser
 from mocks.mock_review import MockReview
 from pages.desktop.consumer_pages.home import Home
 
-from selenium import webdriver
-
 
 class TestReviews:
 

--- a/tests/mobile/test_reviews.py
+++ b/tests/mobile/test_reviews.py
@@ -94,7 +94,7 @@ class TestReviews():
         add_review_box = AddReview(mozwebqa)
         details_page = add_review_box.write_a_review(mock_review['rating'], mock_review['body'])
 
-        details_page.wait_for_ajax_on_page_finish()
+        details_page.wait_for_page_to_load()
         Assert.true(details_page.is_success_message_visible, "Review not added: %s" % details_page.success_message)
         Assert.equal(details_page.success_message, "Your review was posted")
 


### PR DESCRIPTION
The tests are failing on <code>execute_script('return jQuery.active == 0')</code>
it seems that requests.js in fireplace no longer uses jquery for xhr at all.
Please see https://github.com/mozilla/fireplace/commit/9ebebef1c9475c2f35d7b232231f477d22f20307
