### PR TITLE
add summary in mock objects since API test still needs it

### DIFF
--- a/mocks/marketplace_api.py
+++ b/mocks/marketplace_api.py
@@ -61,6 +61,7 @@ class MarketplaceAPI:
 
         data = {
             'name': mock_app.name,
+            'summary': mock_app.summary,
             'categories': [],
             'support_email': mock_app.support_email,
             'device_types': [],

--- a/mocks/mock_application.py
+++ b/mocks/mock_application.py
@@ -15,6 +15,7 @@ class MockApplication(dict):
         self['app_type'] = 'hosted'
         self['name'] = 'Mock Application %s' % current_time
         self['url_end'] = 'marble-run-%s' % current_time
+        self['summary'] = 'Summary of marble app %s' % current_time 
         self['categories'] = [('Entertainment', True),
                              ('Games', True)]
         self['description'] = 'more details of marble app %s' % current_time


### PR DESCRIPTION
Summary field has only been removed from Developer Pages and not the API. The Marketpalce Python API client checks for `summary` in the `update` method, doesn't find it and raises an exception. This is causing the test to fail.
