### PR TITLE
xfail editing review test due to #320

### DIFF
--- a/tests/desktop/consumer_pages/test_reviews.py
+++ b/tests/desktop/consumer_pages/test_reviews.py
@@ -49,6 +49,7 @@ class TestReviews:
         Assert.equal(details_page.first_review_rating, mock_review['rating'])
         Assert.equal(details_page.first_review_body, mock_review['body'])
 
+    @pytest.mark.xfail(reason="Need different apps for different tests for reviews. Issue https://github.com/mozilla/marketplace-tests/issues/320.")
     def test_that_checks_the_editing_of_a_review(self, mozwebqa):
 
         mk_api = MarketplaceAPI(credentials=mozwebqa.credentials['api'])  # init API client


### PR DESCRIPTION
Conflicts when one test is trying to submit review when another test already submitted it and is still running.

https://github.com/mozilla/marketplace-tests/issues/320
