### PR TITLE
Readding xfail

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -215,6 +215,7 @@ class TestDeveloperHub(BaseTest):
                 if not my_apps.paginator.is_first_page_disabled:
                     my_apps.paginator.click_next_page()
 
+    @pytest.mark.xfail(reason="Bug 800341 - Basic Information section is not closed after changes are saved")
     def test_that_checks_editing_basic_info_for_a_free_app(self, mozwebqa):
         """Test the happy path for editing the basic information for a free submitted app.
 


### PR DESCRIPTION
Adding the xfail because https://bugzilla.mozilla.org/show_bug.cgi?id=800341 was reopened and test fails on CI 
http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.dev.developer_hub/lastCompletedBuild/testReport/tests.desktop.developer_hub.test_developer_hub/TestDeveloperHub/test_that_checks_editing_basic_info_for_a_free_app/
