### PR TITLE
click back in settings region instead of marketplace icon

### DIFF
--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -67,7 +67,7 @@ class Base(Page):
         _search_suggestions_title_locator = (By.CSS_SELECTOR, '#site-search-suggestions div.wrap > p > a > span')
         _search_suggestions_locator = (By.ID, 'site-search-suggestions')
         _search_suggestion_locator = (By.CSS_SELECTOR, '#site-search-suggestions > div.wrap > ul > li')
-        _back_button_locator = (By.CSS_SELECTOR, '#nav-back > b')
+        _back_button_locator = (By.CSS_SELECTOR, '#nav-back')
         _account_settings_locator = (By.CSS_SELECTOR, '.account-links > a.settings')
         _marketplace_icon_locator = (By.CSS_SELECTOR, '.wordmark')
 

--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -40,5 +40,5 @@ class TestAccounts():
         settings_page.click_apps()
         Assert.equal("My Apps", settings_page.selected_settings_option)
 
-        settings_page.header.click_marketplace_icon()
+        settings_page.header.click_back()
         Assert.true(home_page.is_featured_section_visible)


### PR DESCRIPTION
To fix this failure: http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.dev.mobile.saucelabs/lastCompletedBuild/testReport/tests.mobile.test_users_account/TestAccounts/test_user_can_go_back_from_settings_page/

Although the test still fails after that because the back button is not supposed to work like `history.back()` in my opinion. The test was passing until yesterday so I assume something has gone wrong.
