### PR TITLE
Test details page bug fixed and xfailed test_user_can_go_back_from_setti...

### DIFF
--- a/tests/desktop/consumer_pages/test_details_page.py
+++ b/tests/desktop/consumer_pages/test_details_page.py
@@ -16,7 +16,6 @@ class TestDetailsPage:
     search_term = 'Twitter'
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="Bug 893283 - Developer's name is missing from app")
     def test_that_application_page_contains_proper_objects(self, mozwebqa):
         """Moztrap 58181"""
 

--- a/tests/mobile/test_details_page.py
+++ b/tests/mobile/test_details_page.py
@@ -13,7 +13,6 @@ from pages.mobile.home import Home
 class TestDetails():
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="Bug 893283 - Developer's name is missing from app")
     def test_details_page_for_an_app(self, mozwebqa):
         """https://moztrap.mozilla.org/runtests/run/243/env/112/ - Verify details page for an app"""
         home_page = Home(mozwebqa)

--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -26,6 +26,7 @@ class TestAccounts():
         Assert.true(settings_page.is_sign_in_visible)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Bug 804759 - Back arrow on Settings pages should return user to Marketplace home page")
     def test_user_can_go_back_from_settings_page(self, mozwebqa):
         """
         https://bugzilla.mozilla.org/show_bug.cgi?id=795185#c11


### PR DESCRIPTION
This was intended from the beginning -> Visit Settings, click Apps, click Back, test that the current page is the homepage.
https://bugzilla.mozilla.org/show_bug.cgi?id=795185#c11
I wanted to change the test but it seems that this is not the normal behaviour so I reopened bug https://bugzilla.mozilla.org/show_bug.cgi?id=804759
and xfailed test
