### PR TITLE
xfail test_user_can_go_back_from_settings_page on prod as back button for settings has not made it to prod yet

### DIFF
--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -30,6 +30,10 @@ class TestAccounts():
         """
         https://bugzilla.mozilla.org/show_bug.cgi?id=795185#c11
         """
+
+        if 'marketplace.firefox.com' in mozwebqa.base_url:
+            pytest.xfail('Back button for settings has not made it to production.')
+
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 


### PR DESCRIPTION
Unfortunately there is no open bug for this in bugzilla. However, `marketplace-tests` and `gaia-ui-tests` both caught that the home icon on settings page has now been replaced by a back button.

This can be observed on `dev`. However, the change has not made it to `prod` yet.
