### PR TITLE
add app name for details page tests

### DIFF
--- a/tests/mobile/test_details_page.py
+++ b/tests/mobile/test_details_page.py
@@ -12,22 +12,24 @@ from pages.mobile.home import Home
 
 class TestDetails():
 
+    APP_NAME = 'Twitter'
+
     @pytest.mark.nondestructive
     def test_details_page_for_an_app(self, mozwebqa):
         """https://moztrap.mozilla.org/runtests/run/243/env/112/ - Verify details page for an app"""
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        #first app name
-        first_featured_app_name = home_page.featured_apps[0].name
+        # search
+        search_page = home_page.search_for(self.APP_NAME)
 
         #click first app and load its Details Page
-        details_page = home_page.featured_apps[0].click()
+        details_page = search_page.results[0].click_app()
         details_page.click_more_button()
 
         #The verifications required by the testcase
         Assert.true(details_page.header.is_back_button_visible)
-        Assert.true(first_featured_app_name in details_page.title)
+        Assert.true(self.APP_NAME in details_page.title)
         Assert.true(details_page.is_author_visible)
         Assert.true(details_page.is_app_icon_present)
         Assert.true(details_page.is_rating_visible)


### PR DESCRIPTION
Featured apps keep on changing on prod. We can't depend on that since some apps don't have enough description to have a `more` button.
