### PR TITLE
Removed adding a review xfail

### DIFF
--- a/pages/desktop/consumer_pages/add_review.py
+++ b/pages/desktop/consumer_pages/add_review.py
@@ -6,6 +6,7 @@
 
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
 
 from pages.desktop.consumer_pages.base import Base
 
@@ -15,6 +16,7 @@ class AddReview(Base):
     _star_rating_locator = (By.CSS_SELECTOR, '.ratingwidget.stars.large.stars-0 > label')
     _add_review_input_field_locator = (By.CSS_SELECTOR, '.add-review-form p #id_body')
     _submit_review_button_locator = (By.CSS_SELECTOR, '.two-up > button[type="submit"]')
+    _notification_locator = (By.ID, 'notification')
 
     _add_review_box = (By.ID, 'feedback-form')
 
@@ -31,6 +33,9 @@ class AddReview(Base):
         self.selenium.find_element(*self._submit_review_button_locator).click()
         from pages.desktop.consumer_pages.details import Details
         return Details(self.testsetup)
+
+        WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: s.find_element(*self._notification_locator).is_displayed())
 
     @property
     def is_review_box_visible(self):

--- a/tests/desktop/consumer_pages/test_reviews.py
+++ b/tests/desktop/consumer_pages/test_reviews.py
@@ -28,8 +28,6 @@ class TestReviews:
             mock_review.body,
             mock_review.rating)
 
-
-    @pytest.mark.skipif("webdriver.__version__ >= '2.32.0'", reason='Issue 5735: Firefox-Driver 2.33.0 falsely reports elements not to be visible')
     def test_that_checks_the_addition_of_a_review(self, mozwebqa):
         self._reviews_setup(mozwebqa)
 
@@ -60,10 +58,12 @@ class TestReviews:
         details_page = add_review_box.write_a_review(mock_review['rating'], mock_review['body'])
 
         # Step 4 - Check review
-        Assert.true(details_page.notification_visible, "Review not added: %s" % details_page.success_message)
         Assert.equal(details_page.notification_message, "Your review was posted")
         Assert.equal(details_page.first_review_rating, mock_review['rating'])
         Assert.equal(details_page.first_review_body, mock_review['body'])
+
+        # Clean up
+        self.mk_api.delete_app_review(self.review_id)
 
     def test_that_checks_the_editing_of_a_review(self, mozwebqa):
 
@@ -100,7 +100,6 @@ class TestReviews:
         # Clean up
         self.mk_api.delete_app_review(self.review_id)
 
-    @pytest.mark.xfail(reason="Need different apps for different tests for reviews. Issue https://github.com/mozilla/marketplace-tests/issues/320.")
     def test_that_checks_the_deletion_of_a_review(self, mozwebqa):
         """
         https://moztrap.mozilla.org/manage/case/648/


### PR DESCRIPTION
Removing these xfails because "Issue 5735: Firefox-Driver 2.33.0 falsely reports elements not to be visible" is no longer reproducible with Selenium 2.35
