### PR TITLE
Changed the wait for page to load

### DIFF
--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -28,7 +28,7 @@ class Base(Page):
 
     def wait_for_page_to_load(self):
         WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._load_page_details_baloon_locator)
-                                                         and not self.is_element_visible(*self._load_home_page_balloon_locator))
+                                                         and self.is_element_not_visible(*self._load_home_page_balloon_locator))
 
     def scroll_to_element(self, *locator):
         """Scroll to element"""


### PR DESCRIPTION
This fixes http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.dev/lastCompletedBuild/testReport/tests.desktop.consumer_pages.test_consumers_page/TestConsumerPage/test_opening_every_category_page_from_categories_section/
Method <code>is_element_not_visible</code> is there, so why not use it?
i don't know if that wait was correct, waiting for the element not to be visible
Seems to fix the test for me, tested locally
