### PR TITLE
Re-enable test_user_can_go_back_from_settings_page on mobile

### DIFF
--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -26,7 +26,6 @@ class TestAccounts():
         Assert.true(settings_page.is_sign_in_visible)
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="Issue 381: https://github.com/mozilla/marketplace-tests/issues/381")
     def test_user_can_go_back_from_settings_page(self, mozwebqa):
         """
         https://bugzilla.mozilla.org/show_bug.cgi?id=795185#c11


### PR DESCRIPTION
This test is now as XPASSED on CI
http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.dev.mobile.saucelabs/403/HTML_Report/?
