### PR TITLE
Fix for busted screenshot test

### DIFF
--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -33,7 +33,7 @@ class EditListing(Base):
     _email_locator = (By.CSS_SELECTOR, 'div[data-name="support_email"] span')
     _website_locator = (By.CSS_SELECTOR, 'div[data-name="support_url"] span')
     _icon_preview_img_locator = (By.CSS_SELECTOR, '#icon_preview_readonly > img')
-    _screenshots_previews_locator = (By.CSS_SELECTOR, 'td.edit-previews-readonly > div > div.preview-successful')
+    _screenshots_previews_locator = (By.CSS_SELECTOR, 'td.edit-previews-readonly > div > div.preview-thumb')
     _save_changes_locator = (By.CSS_SELECTOR, 'div.listing-footer > button')
     _loading_locator = (By.CSS_SELECTOR, 'div.item.island.loading')
 


### PR DESCRIPTION
`preview-successful` is added via JS and there's no guarantee it will be added by the time the test has finished running. This change eliminates the race condition.
