### PR TITLE
Change JS expression to also wait for jQuery to be present

### DIFF
--- a/pages/desktop/developer_hub/base.py
+++ b/pages/desktop/developer_hub/base.py
@@ -62,6 +62,6 @@ class Base(Page):
             element.click()
             from pages.desktop.developer_hub.developer_submissions import DeveloperSubmissions
             dev_submissions = DeveloperSubmissions(self.testsetup)
-            WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.execute_script('return jQuery.active == 0')
+            WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.execute_script('return jQuery && jQuery.active == 0')
                                                              and dev_submissions.is_the_current_page)
             return dev_submissions

--- a/pages/desktop/developer_hub/compatibility_and_payments.py
+++ b/pages/desktop/developer_hub/compatibility_and_payments.py
@@ -55,7 +55,7 @@ class CompatibilityAndPayments(Base):
             if option.text == price:
                 option.click()
                 WebDriverWait(self.selenium, self.timeout).until(
-                    lambda s: self.selenium.execute_script('return jQuery.active == 0')
+                    lambda s: self.selenium.execute_script('return jQuery && jQuery.active == 0')
                     and'loading' not in s.find_element(*self._price_section_locator).get_attribute('class').split(' '))
                 break
 

--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -47,19 +47,19 @@ class EditListing(Base):
     def click_edit_basic_info(self):
         self.selenium.find_element(*self._edit_basic_info_locator).click()
         WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
-            and self.selenium.execute_script('return jQuery.active == 0'))
+            and self.selenium.execute_script('return jQuery && jQuery.active == 0'))
         return self.basic_info
 
     def click_support_information(self):
         self.selenium.find_element(*self._edit_support_information_locator).click()
         WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
-            and self.selenium.execute_script('return jQuery.active == 0'))
+            and self.selenium.execute_script('return jQuery && jQuery.active == 0'))
         return self.support_information
 
     def click_edit_media(self):
         self.selenium.find_element(*self._edit_media_locator).click()
         WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
-            and self.selenium.execute_script('return jQuery.active == 0'))
+            and self.selenium.execute_script('return jQuery && jQuery.active == 0'))
         return self.media
 
     @property
@@ -188,7 +188,7 @@ class EditListing(Base):
         def click_save_changes(self):
             self.selenium.find_element(*self._save_changes_locator).click()
             WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
-                and self.selenium.execute_script('return jQuery.active == 0'))
+                and self.selenium.execute_script('return jQuery && jQuery.active == 0'))
 
         def click_cancel(self):
             self.selenium.find_element(*self._cancel_link_locator).click()
@@ -209,7 +209,7 @@ class EditListing(Base):
         def click_save_changes(self):
             self.selenium.find_element(*self._save_changes_locator).click()
             WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
-                and self.selenium.execute_script('return jQuery.active == 0'))
+                and self.selenium.execute_script('return jQuery && jQuery.active == 0'))
 
     class MediaRegion(Page):
 
@@ -268,7 +268,7 @@ class EditListing(Base):
         def click_save_changes(self, expected_result='success'):
             self.selenium.find_element(*self._save_changes_locator).click()
             WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._loading_locator)
-                and self.selenium.execute_script('return jQuery.active == 0'))
+                and self.selenium.execute_script('return jQuery && jQuery.active == 0'))
 
         def click_cancel(self):
             self.selenium.find_element(*self._cancel_link_locator).click()

--- a/pages/desktop/regions/paginator.py
+++ b/pages/desktop/regions/paginator.py
@@ -30,7 +30,7 @@ class Paginator(Page):
     _total_item_number = (By.CSS_SELECTOR, 'nav.paginator .pos b:nth-child(3)')
 
     def _wait_for_results_refresh(self):
-        WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.execute_script('return jQuery.active == 0'))
+        WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.execute_script('return jQuery && jQuery.active == 0'))
 
     @property
     def is_paginator_present(self):

--- a/pages/desktop/regions/sorter.py
+++ b/pages/desktop/regions/sorter.py
@@ -37,7 +37,7 @@ class Sorter(Page):
         """
         click_element = self.selenium.find_element(*getattr(self, '_sort_by_%s_locator' % type.replace(' ', '_').lower()))
         click_element.click()
-        WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.execute_script("return jQuery.active == 0"))
+        WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.execute_script("return jQuery && jQuery.active == 0"))
 
     @property
     def sorted_by(self):


### PR DESCRIPTION
I noticed that we have had a number of failures where an exception is thrown when we check for `jQuery.active == 0` because `jQuery` is not defined. It seems like maybe we are checking too quickly, and jQuery is not available in the DOM yet.  This patch simply changes the logic so that we are checking if `jQuery` is defined _and_ if `jQuery.active == 0`. The first check should short-circuit the second check, so we wouldn't check if `jQuery.active == 0` unless `jQuery` is defined.

As this change was made in a number of places this should be tested via a complete run of the desktop suite. 
