### PR TITLE
Enhance login wait, remove home_page wait and skip 'purchase app' test

### DIFF
--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -16,7 +16,6 @@ from mocks.mock_user import MockUser
 class Base(Page):
 
     _login_locator = (By.CSS_SELECTOR, '.header-button.persona')
-    _persona_loading_balloon_locator = (By.CSS_SELECTOR, '.persona.loading-submit')
     _load_home_page_balloon_locator = (By.CSS_SELECTOR, '.throbber')
     _load_page_details_baloon_locator = (By.CSS_SELECTOR, '.spinner.padded.alt')
     _notification_locator = (By.ID, 'notification')
@@ -28,8 +27,8 @@ class Base(Page):
         return self.selenium.title
 
     def wait_for_page_to_load(self):
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._load_page_details_baloon_locator)
-                                                         and self.is_element_not_visible(*self._load_home_page_balloon_locator))
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_not_visible(*self._load_home_page_balloon_locator)
+                                                        and not self.is_element_present(*self._load_page_details_baloon_locator))
 
     def scroll_to_element(self, *locator):
         """Scroll to element"""
@@ -43,8 +42,8 @@ class Base(Page):
         bid_login = self.click_login_register(expect='new')
         bid_login.sign_in(credentials['email'], credentials['password'])
 
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_present(*self._persona_loading_balloon_locator)
-                                                         and not self.wait_notification_box_visible())
+        self.wait_notification_box_visible()
+        self.wait_notification_box_not_visible()
 
     def click_login_register(self, expect='new'):
         """Click the 'Log in/Register' button.

--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -16,12 +16,10 @@ class Home(Base):
     _category_section_title_locator = (By.CSS_SELECTOR, '.cat-all.cat-icon')
     _category_count_locator = (By.CSS_SELECTOR, '.cat-icons.c > li:not(:nth-child(1))')
     _first_app_locator = (By.CSS_SELECTOR, '#featured > ol > li:first-child > a')
-    _throbber_locator = (By.CLASS_NAME, 'throbber')
 
     def go_to_homepage(self):
         self.selenium.get(self.base_url)
         self.maximize_window()
-        self.wait_for_element_not_visible(*self._throbber_locator)
         self.wait_for_element_visible(*self._featured_section_locator)
 
     @property

--- a/tests/desktop/consumer_pages/test_purchase_app.py
+++ b/tests/desktop/consumer_pages/test_purchase_app.py
@@ -15,7 +15,7 @@ class TestPurchaseApp:
 
     _app_name = 'Papa Smurf'
 
-    @pytest.mark.xfail(reason="Purchase app option is currently not available for desktop environment")
+    @pytest.mark.skipif('True', reason='Purchase app option is currently not available for desktop environment')
     def test_that_purchases_an_app_without_pre_auth_and_requests_a_refund(self, mozwebqa):
         """Litmus 58166"""
         home_page = Home(mozwebqa)

--- a/tests/desktop/consumer_pages/test_reviews.py
+++ b/tests/desktop/consumer_pages/test_reviews.py
@@ -62,6 +62,8 @@ class TestReviews:
         # Step 4 - Check review
         details_page.wait_notification_box_visible()
         Assert.equal(details_page.notification_message, "Your review was posted")
+        details_page.wait_notification_box_not_visible()
+
         Assert.equal(details_page.first_review_rating, mock_review['rating'])
         Assert.equal(details_page.first_review_body, mock_review['body'])
 
@@ -95,7 +97,9 @@ class TestReviews:
         details_page = edit_review.write_a_review(mock_review['rating'], mock_review['body'])
 
         # Check notification
+        details_page.wait_notification_box_visible()
         Assert.equal(details_page.notification_message, "Review updated successfully")
+        details_page.wait_notification_box_not_visible()
 
         # Go to reviews page and verify
         reviews = details_page.click_reviews_button()
@@ -117,7 +121,6 @@ class TestReviews:
         home_page.go_to_homepage()
 
         home_page.login(user="default")
-        home_page.wait_notification_box_not_visible()
         Assert.true(home_page.is_the_current_page)
 
         # Step 3 - Search for the test app and go to its details page

--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -19,7 +19,7 @@ class TestAccounts(BaseTest):
         home_page.go_to_homepage()
 
         home_page.login()
-        Assert.true(home_page.notification_visible)
+        Assert.false(home_page.header.is_sign_in_visible)
         Assert.true(home_page.is_the_current_page)
 
         home_page.header.hover_over_settings_menu()


### PR DESCRIPTION
http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.prod/723/testReport/junit/tests.desktop.consumer_pages.test_users_account/TestAccounts/test_user_can_sign_in_and_sign_out_in_consumer_pages/

or 

http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.prod/696/testReport/

Prod is intermittently failing on _throbber_locator, we should just remove it as we already waiting for Favorite apps to appear
