### PR TITLE
Remove xfail from test_user_can_go_back_from_settings_page().

### DIFF
--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -25,7 +25,6 @@ class TestAccounts():
         settings_page.click_logout()
         Assert.true(settings_page.is_sign_in_visible)
 
-    @pytest.mark.xfail(reason="Issue 381: https://github.com/mozilla/marketplace-tests/issues/381")
     @pytest.mark.nondestructive
     def test_user_can_go_back_from_settings_page(self, mozwebqa):
         """


### PR DESCRIPTION
The test was xfailed for the reason mentioned in the following comment [1]. I have checked the latest builds and in most of them the test XPasses. In the situations where it fails it is for other reasons than the one mentioned in #381.
I removed the xfail so that the job fails if the test encounters other errors.

[1] https://github.com/mozilla/marketplace-tests/issues/381#issuecomment-27481352
