### PR TITLE
Fix for issue 434

### DIFF
--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -224,6 +224,7 @@ class EditListing(Base):
                                 'div.preview-thumb[style^="background-image"]:not([class~="error-loading"])')
         _screenshot_upload_locator = (By.CSS_SELECTOR, '#edit-addon-media div.invisible-upload > input.screenshot_upload')
         _screenshot_loading_locator = (By.CSS_SELECTOR, 'div.preview-thumb.loading')
+        _screenshot_preview_error_locator = (By.CSS_SELECTOR, 'div.preview-thumb.preview-error')
         _screenshot_upload_error_message_locator = (By.CSS_SELECTOR, 'div.edit-previews-text.error')
         _save_changes_locator = (By.CSS_SELECTOR, 'div.listing-footer > button')
         _cancel_link_locator = (By.CSS_SELECTOR, 'div.edit-media-button > a')
@@ -264,6 +265,7 @@ class EditListing(Base):
             element = self.selenium.find_element(*self._screenshot_upload_locator)
             element.send_keys(value)
             self.wait_for_element_not_present(*self._screenshot_loading_locator)
+            self.wait_for_element_not_present(*self._screenshot_preview_error_locator)
 
         def click_save_changes(self, expected_result='success'):
             self.selenium.find_element(*self._save_changes_locator).click()


### PR DESCRIPTION
Issue https://github.com/mozilla/marketplace-tests/issues/434
As you can see in the screenshot the test does not wait if images are in preview-error state.
Let us see if this helps. 
I will start and adhoc job.
Screenshot: http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.stage.developer_hub.saucelabs/620/HTML_Report/debug/tests_desktop_developer_hub_test_developer_hub_TestDeveloperHub/test_that_a_screenshot_can_be_added/screenshot.png
Adhoc job: http://qa-selenium.mv.mozilla.com:8080/view/Marketplace/job/marketplace.stage.developer_hub.saucelabs.fix/
