### PR TITLE
Update marketplace_api.py to expect status code 201 when adding content ratings

### DIFF
--- a/mocks/marketplace_api.py
+++ b/mocks/marketplace_api.py
@@ -103,7 +103,7 @@ class MarketplaceAPI:
             response_data = json.loads(response.content)
         except ValueError:
             response_data = 'Unknown'
-        Assert.equal(response.status_code, 204,
+        Assert.equal(response.status_code, 201,
                      "Content ratings not added.\n Status code %s\nResponse data %s" %
                      (response.status_code, response_data))
 


### PR DESCRIPTION
To support the change introduced in https://github.com/mozilla/zamboni/pull/1801
