### PR TITLE
Review tests are failing because waiting for page to load takes to long

### DIFF
--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -41,7 +41,6 @@ class Details(Base):
 
     def __init__(self, testsetup, app_name=False):
         Base.__init__(self, testsetup)
-        self.wait_for_page_to_load()
         if app_name:
             self._page_title = "%s | Firefox Marketplace" % app_name
             self.app_name = app_name


### PR DESCRIPTION
Waiting for page to load in the Details page takes to long and the notification message then disappears.
So that wait is not really needed here/ does not help in any way.
We already have the wait for notification.
