### PR TITLE
Restoring coverage for mobile tests

### DIFF
--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -35,13 +35,10 @@ class Base(Page):
         self.selenium.execute_script("window.scrollTo(0, %s)" % (el.location['y'] + el.size['height']))
 
     def search_for(self, search_term):
-        if self.header.is_search_button_visible:
-            self.header.click_search()
-
         Assert.true(self.header.is_search_visible)
         self.header.type_in_search_field(search_term)
         self.header.submit_search()
-        self.wait_for_page_to_load()
+
         from pages.mobile.search import Search
         return Search(self.testsetup)
 
@@ -65,7 +62,6 @@ class Base(Page):
 
     class Header(Page):
         _settings_button_locator = (By.CSS_SELECTOR, '.settings')
-        _search_button_locator = (By.CSS_SELECTOR, '.header-button.icon.search.right')
         _search_locator = (By.ID, 'search-q')
         _search_suggestions_title_locator = (By.CSS_SELECTOR, '#site-search-suggestions div.wrap > p > a > span')
         _search_suggestions_locator = (By.ID, 'site-search-suggestions')
@@ -88,14 +84,6 @@ class Base(Page):
             self.selenium.find_element(*self._settings_button_locator).click()
             from pages.mobile.settings import Account
             return Account(self.testsetup)
-
-        def click_search(self):
-            self.selenium.find_element(*self._search_button_locator).click()
-            self.wait_for_element_present(*self._search_locator)
-
-        @property
-        def is_search_button_visible(self):
-            return self.is_element_visible(*self._search_button_locator)
 
         @property
         def is_account_settings_visible(self):

--- a/pages/mobile/details.py
+++ b/pages/mobile/details.py
@@ -23,7 +23,7 @@ class Details(Base):
     _more_less_locator = (By.CLASS_NAME, 'show-toggle')
     _rating_count_locator = (By.CSS_SELECTOR, '.average-rating > span:nth-child(1)')
     _reviews_locator = (By.CSS_SELECTOR, '.reviews > .ratings-placeholder-inner > li')
-    _support_section_buttons_locator = (By.CSS_SELECTOR, '#support .c li')
+    _support_section_buttons_locator = (By.CSS_SELECTOR, '#ph_9 .c li')
     _app_not_rated_yet_locator = (By.CLASS_NAME, 'not-rated')
 
     @property

--- a/tests/mobile/test_details_page.py
+++ b/tests/mobile/test_details_page.py
@@ -43,7 +43,7 @@ class TestDetails():
         home_page.go_to_homepage()
 
         # click first app and load its Details Page
-        details_page = home_page.featured_apps[1].click()
+        details_page = home_page.featured_apps[0].click()
 
         # This takes the number of reviews on the details page and based on that number it treats 3 different scenarios:
         # when the app has reviews, when it has 1 review and when the app isn't rated.

--- a/tests/mobile/test_reviews.py
+++ b/tests/mobile/test_reviews.py
@@ -20,6 +20,8 @@ class TestReviews():
     def _reviews_setup(self, mozwebqa):
         self.mk_api = MarketplaceAPI.get_client(mozwebqa.base_url, mozwebqa.credentials)
 
+    @pytest.mark.xfail(reason="Issue 500 Login tests currently don't work on Saucelabs")
+    # https://github.com/mozilla/marketplace-tests/issues/500
     def test_that_after_writing_a_review_clicking_back_goes_to_app_page(self, mozwebqa):
         """Logged out, click "Write a Review" on an app page, sign in, submit a review,
         click Back, test that the current page is the app page.
@@ -86,6 +88,8 @@ class TestReviews():
         Assert.true(details_page.is_product_details_visible)
         Assert.equal(app_name, details_page.title)
 
+    @pytest.mark.xfail(reason="Issue 500 Login tests currently don't work on Saucelabs")
+    # https://github.com/mozilla/marketplace-tests/issues/500
     def test_that_checks_the_addition_of_a_review(self, mozwebqa):
         self._reviews_setup(mozwebqa)
 

--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -13,6 +13,8 @@ from pages.mobile.home import Home
 class TestAccounts():
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Issue 500 Login tests currently don't work on Saucelabs")
+    # https://github.com/mozilla/marketplace-tests/issues/500
     def test_user_can_login_and_logout(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
@@ -26,6 +28,8 @@ class TestAccounts():
         Assert.true(settings_page.is_sign_in_visible)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Issue 500 Login tests currently don't work on Saucelabs")
+    # https://github.com/mozilla/marketplace-tests/issues/500
     def test_user_can_go_back_from_settings_page(self, mozwebqa):
         """
         https://bugzilla.mozilla.org/show_bug.cgi?id=795185#c11


### PR DESCRIPTION
This is for issue https://github.com/mozilla/marketplace-tests/issues/500

Currently the Login tests do not work on Saucelabs for Marketplace mobile, you can see the behavior here: https://saucelabs.com/tests/07b99aa2687a4867926b5fc1f2c16f38
