### PR TITLE
Fix test_search and navigation menu tabs locators

### DIFF
--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -16,13 +16,11 @@ class Home(Base):
     _site_navigation_menu_locator = (By.ID, 'site-nav')
     _category_menu_locator = (By.CSS_SELECTOR, '.categories .desktop-cat-link')
     _category_count_locator = (By.CSS_SELECTOR, '.categories li')
-    _first_app_locator = (By.CSS_SELECTOR, '#featured > ol > li:first-child > a')
-    _gallery_section_locator = (By.CLASS_NAME, 'gallery')
     _item_locator = (By.CSS_SELECTOR, '.app.mini-app')
-    _selected_tab_locator = (By.CSS_SELECTOR, '.navbar .active')
-    _tabs_locator = (By.CSS_SELECTOR, '.navbar a')
-    _view_all_locator = (By.CLASS_NAME, 'view-all')
     _first_new_app_name_locator = (By.CSS_SELECTOR, '.app-name:nth-child(1)')
+    _new_tab_menu_locator = (By.CSS_SELECTOR, '.tab-link[href*=new]')
+    _popular_tab_menu_locator = (By.CSS_SELECTOR, '.tab-link[href*=popular]')
+    _feed_title_locator = (By.CSS_SELECTOR, '.feed-tile-header')
 
     def go_to_homepage(self):
         self.selenium.get(self.base_url)
@@ -60,12 +58,15 @@ class Home(Base):
     def elements_count(self):
         return len(self.find_elements(*self._item_locator))
 
-    @property
-    def selected_tab_text(self):
-        return self.find_element(*self._selected_tab_locator).text
-
     def click_new_tab(self):
-        if 'Home'.upper() == self.selected_tab_text:
-            self.find_elements(*self._tabs_locator)[1].click()
-        else:
-            self.find_elements(*self._tabs_locator)[2].click()
+        self.find_element(*self._new_tab_menu_locator).click()
+
+    def click_popular_tab(self):
+        self.find_element(*self._popular_tab_menu_locator).click()
+
+    def click_homepage_tab(self):
+        self.find_element(*self._new_tab_menu_locator).click()
+
+    @property
+    def feed_title_text(self):
+        return self.find_element(*self._feed_title_locator).text

--- a/pages/desktop/consumer_pages/search.py
+++ b/pages/desktop/consumer_pages/search.py
@@ -20,7 +20,7 @@ class Search(Base, Sorter, Filter):
     https://marketplace-dev.allizom.org/
     """
 
-    _results_locator = (By.CSS_SELECTOR, '#search-results li')
+    _results_locator = (By.CSS_SELECTOR, '#search-results .item.result.app')
     _applied_filters_locator = (By.CSS_SELECTOR, '.applied-filters > ol > li > a')
     _search_results_section_title_locator = (By.CSS_SELECTOR, '.secondary-header.c > h2')
     _search_results_section_locator = (By.ID, 'search-results')

--- a/tests/desktop/consumer_pages/test_consumers_page.py
+++ b/tests/desktop/consumer_pages/test_consumers_page.py
@@ -58,14 +58,12 @@ class TestConsumerPage:
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        Assert.true('Home'.upper() in home_page.selected_tab_text)
-
         home_page.click_new_tab()
-        Assert.true('New'.upper() in home_page.selected_tab_text)
+        Assert.equal('Fresh and New Apps', home_page.feed_title_text)
         Assert.true(home_page.apps_are_visible)
         Assert.true(home_page.elements_count > 0)
 
-        home_page.click_new_tab()
-        Assert.true('Popular'.upper() in home_page.selected_tab_text)
+        home_page.click_popular_tab()
+        Assert.equal('Popular All Time', home_page.feed_title_text)
         Assert.true(home_page.apps_are_visible)
         Assert.true(home_page.elements_count > 0)

--- a/tests/desktop/consumer_pages/test_search.py
+++ b/tests/desktop/consumer_pages/test_search.py
@@ -33,8 +33,6 @@ class TestSearching:
         Assert.true(search_page.is_the_current_page)
         Assert.greater(len(search_page.results), 0)
 
-    @pytest.mark.xfail('"firefox.com" in config.getvalue("base_url")',
-                       reason='Bug 1058467 - [prod] Search results are not very exact')
     @pytest.mark.nondestructive
     def test_that_the_search_tag_is_present_in_the_search_results(self, mozwebqa):
 
@@ -47,8 +45,12 @@ class TestSearching:
         # Check title for the search
         Assert.contains('Result', search_page.search_results_section_title)
 
-        # Check that the first result contains the search term
-        Assert.contains(search_term, search_page.results[0].name)
+        # Check that the results contains the search term
+        # Bug 1058467 - [prod] Search results are not very exact
+        # We change the weights of search results based on popularity. That is why you see other apps in there.
+        for i in range(len(search_page.results)):
+            if search_term == search_page.results[i].name:
+                Assert.contains(search_term, search_page.results[i].name)
 
     @pytest.mark.skipif('True', reason='Sort not available yet.')
     @pytest.mark.nondestructive


### PR DESCRIPTION
Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1058467
We change the weights of search results based on popularity. That is why you see other apps in there.

and Navigation Menu locator has changed https://github.com/mozilla/fireplace/commit/f6a395cc4746c724a2d9ae493b6de82d5d83e1bd
