### PR TITLE
Xfail screenshot test with the right reason

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -121,8 +121,7 @@ class TestDeveloperHub(BaseTest):
         Assert.contains('Please select a device.', compatibility_page.device_types_error_message)
 
     @pytest.mark.credentials
-    @pytest.mark.xfail("'-dev.allizom' in config.getvalue('base_url')",
-                       reason='Bug 977084 - Problems with screenshot previews on the Edit Listing page')
+    @pytest.mark.xfail(reason='Test fails intermittently, issue https://github.com/mozilla/marketplace-tests/issues/549')
     def test_that_a_screenshot_can_be_added(self, mozwebqa_devhub_logged_in, free_app):
         """Test the happy path for adding a screenshot for a free submitted app."""
 


### PR DESCRIPTION
Bug 977084 - Problems with screenshot previews on the Edit Listing page is marked as WORKSFORME
and I couldn't reproduce this locally either.
