### PR TITLE
Change assert type in app name

### DIFF
--- a/tests/mobile/test_reviews.py
+++ b/tests/mobile/test_reviews.py
@@ -83,7 +83,7 @@ class TestReviews():
         reviews_page.header.click_back()
 
         Assert.true(details_page.is_product_details_visible)
-        Assert.equal(app_name, details_page.title)
+        Assert.contains(app_name, details_page.title)
 
     @pytest.mark.xfail(reason='Until issue https://github.com/mozilla/marketplace-tests/issues/568 is fixed')
     def test_that_checks_the_addition_of_a_review(self, mozwebqa):


### PR DESCRIPTION
on Production test fails because app name is "SoundCloud - Music & Audio" and on stage and dev is simple "SoundCloud"

Here is the fail http://selenium.qa.mtv2.mozilla.com:8080/view/Marketplace/job/marketplace.PROD.mobile.saucelabs/1384/HTML_Report/
