### PR TITLE
Change maximize window to set specific window dimensions

### DIFF
--- a/pages/desktop/consumer_pages/account_settings.py
+++ b/pages/desktop/consumer_pages/account_settings.py
@@ -23,7 +23,7 @@ class AccountSettings(Base):
     _settings_sign_in_locator = (By.CSS_SELECTOR, '.account-settings-save a:not(.register)')
 
     def go_to_settings_page(self):
-        self.maximize_window()
+        self.set_window_size()
         self.selenium.get(self.base_url + '/settings')
 
     def click_payment_menu(self):
@@ -122,7 +122,7 @@ class My_Apps(AccountSettings):
     _expand_button_locator = (By.CSS_SELECTOR, '.app-list-filters-content .app-list-filters-expand-toggle')
 
     def go_to_my_apps_page(self):
-        self.maximize_window()
+        self.set_window_size()
         self.selenium.get(self.base_url + '/purchases')
 
     def click_expand_button(self):
@@ -132,7 +132,6 @@ class My_Apps(AccountSettings):
     def apps(self):
         return [self.Apps(self.testsetup, web_element)
                 for web_element in self.selenium.find_elements(*self._my_apps_list_locator)]
-
 
     class Apps(PageRegion):
 

--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -28,10 +28,10 @@ class Home(Base):
     _promo_box_items_locator = (By.CSS_SELECTOR, '.desktop-promo-item')
 
     def go_to_homepage(self):
-        self.maximize_window()
+        self.set_window_size()
         self.selenium.get(self.base_url)
         WebDriverWait(self.selenium, self.timeout).until(
-                    lambda s: self.selenium.execute_script('return jQuery.isReady == true'))
+            lambda s: self.selenium.execute_script('return jQuery.isReady == true'))
         self.wait_for_element_visible(*self._site_navigation_menu_locator)
 
     @property
@@ -49,9 +49,7 @@ class Home(Base):
     def hover_over_categories_menu(self):
         while not self.is_element_visible(*self._categories_tabel_locator):
             hover_element = self.selenium.find_element(*self._category_menu_locator)
-            ActionChains(self.selenium).\
-            move_to_element(hover_element).\
-            perform()
+            ActionChains(self.selenium).move_to_element(hover_element).perform()
 
     @property
     def categories(self):

--- a/pages/desktop/developer_hub/home.py
+++ b/pages/desktop/developer_hub/home.py
@@ -16,7 +16,7 @@ class Home(Base):
     _submit_new_app_locator = (By.CSS_SELECTOR, '.submit[href*=submit]')
 
     def go_to_developers_homepage(self):
-        self.maximize_window()
+        self.set_window_size()
         self.selenium.get("%s/developers/" % self.base_url)
 
     def go_to_app_status_page(self, app):

--- a/pages/page.py
+++ b/pages/page.py
@@ -37,7 +37,8 @@ class Page(object):
             WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
 
         Assert.equal(self.selenium.title, self._page_title,
-            "Expected page title: %s. Actual page title: %s" % (self._page_title, self.selenium.title))
+                     'Expected page title: %s. Actual page title: %s' % (
+                         self._page_title, self.selenium.title))
         return True
 
     def is_element_present(self, *locator):
@@ -127,11 +128,11 @@ class Page(object):
         text_fld.clear()
         text_fld.send_keys(text)
 
-    def maximize_window(self):
-        try:
-            self.selenium.maximize_window()
-        except WebDriverException as e:
-            pass
+    def set_window_size(self):
+        # Marketplace requires a minimum window width
+        # to display elements that we are checking
+        if self.selenium.get_window_size()['width'] < 1280:
+            self.selenium.set_window_size(1280, 1024)
 
     def find_element(self, *locator):
         return self._selenium_root.find_element(*locator)
@@ -160,6 +161,7 @@ class Page(object):
                 break
         if option_found is False:
             raise Exception("Option '" + value + "' was not found, thus not selectable.")
+
 
 class PageRegion(Page):
 


### PR DESCRIPTION
Some of our tests will not display the expected elements unless the browser window is at least 1050 pixels wide. So, rather than simply maximizing the window, we should set it to a specific size that we know will work.

@AndreiH r?
