### PR TITLE
update search placeholder attribute text

### DIFF
--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -34,7 +34,7 @@ class TestConsumerPage(BaseTest):
 
         Assert.true(home_page.header.is_logo_visible)
         Assert.true(home_page.header.is_search_visible)
-        Assert.equal(home_page.header.search_field_placeholder, "Search")
+        Assert.equal(home_page.header.search_field_placeholder, "Search the Marketplace")
         Assert.true(home_page.header.is_sign_in_visible)
 
     @pytest.mark.sanity


### PR DESCRIPTION
The text in the attribute `placeholder` changed from `placeholder="Search"` to `placeholder="Search the Marketplace"`.

It looks like this change landed on dev and stage.

![screenshot 2015-02-05 16 50 07](https://cloud.githubusercontent.com/assets/63193/6071800/3cf3b2e6-ad57-11e4-901a-c8dae97f485b.png)
