### PR TITLE
Update .travis.yml to run flake8 tests and to not run WebDriver tests as they are currently very flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: python
 
-python:
-  - 2.7
+python: 2.7
 
-before_install:
-  - git submodule update --init --recursive
+install: "pip install flake8"
 
-install:
-  - "pip install -Ur requirements.txt"
-
-before_script:
-  - sh -e /etc/init.d/xvfb start
-
-script: py.test tests/desktop -n 4 -v -r fsxXR --baseurl=https://marketplace-dev.allizom.org --driver=firefox --destructive -m "not credentials and not action_chains"
-
-env:
-  - DISPLAY=':99.0'
+before_script: "flake8 . --ignore=E501"
 
 notifications:
-  email:
-    - webqa-ci@mozilla.org
+  email: webqa-ci@mozilla.org


### PR DESCRIPTION
This is based on conversations that we have had. Currently the Travis results are ignored for marketplace-tests as they always fail. We need to determine the value in running the WebDriver tests on Travis, but for now it makes sense to just not run them, imo. We can, however, run the flake8 check, which should catch pep8 issues on pull requests.

This new `.travis.yml` is my attempt to do the above. Reviews appreciated.

Also, once we implement this Travis will fail as long as there are any existing pep8 issues, but I think that's fine as it's failing now anyway. Once we implement this we can then look for a PR that will fix any existing pep8 issues.

@davehunt r?
