### PR TITLE
Use fxapom from PyPI now that the package has been deployed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ chardet==2.1.1
 execnet==1.1
 requests==2.4.3
 Marketplace==0.9.1
--e git+https://github.com/bobsilverberg/fxapom.git@master#egg=fxapom
+fxapom==1.0


### PR DESCRIPTION
fxapom has finally been released as a package on PyPI [1], so this updates the marketplace-tests repo to use that version.

[1] https://pypi.python.org/pypi/fxapom