### PR TITLE
This fixes test_that_application_page_contains_proper_objects which is failing on dev and stage

### DIFF
--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -27,7 +27,7 @@ class Details(Base):
     _app_site_locator = (By.CSS_SELECTOR, '.support-url > a')
     _app_dev_username_locator = (By.CSS_SELECTOR, '.author')
     _application_description_locator = (By.CSS_SELECTOR, '.description')
-    _image_preview_section_locator = (By.CSS_SELECTOR, '.slider')
+    _image_preview_section_locator = (By.CSS_SELECTOR, '.previews-slider')
     _content_ratings_button_locator = (By.CSS_SELECTOR, '.content-ratings-wrapper .full .button')
     _content_ratings_image_locator = (By.CSS_SELECTOR, '.content-rating img')
     _privacy_policy_locator = (By.CSS_SELECTOR, '#footer a[href*="privacy"]')

--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -58,7 +58,7 @@ class TestAccounts(BaseTest):
         settings_page.go_to_my_apps_page()
 
         settings_page.click_account_settings_sign_in()
-        acct = self.create_new_user(mozwebqa))
+        acct = self.create_new_user(mozwebqa)
         settings_page.login(acct)
 
         Assert.true(settings_page.header.is_user_logged_in)


### PR DESCRIPTION
Failure as seen at https://webqa-ci.mozilla.com/job/marketplace.dev.sanity.saucelabs/9/HTML_Report/

Note that this will allow the job to pass on dev and stage, but will cause it to fail on prod until this change is pushed.

@m8ttyB / @stephendonner r?

This also fixes a syntax error in `test_users_account.py`. I am surprised this wasn't being picked up by the jobs on Jenkins.