### PR TITLE
Xfail tests that upload screenshots due to issue #618

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -120,6 +120,7 @@ class TestDeveloperHub(BaseTest):
         compatibility_page.click_save_changes()
         Assert.contains('Please select a device.', compatibility_page.device_types_error_message)
 
+    @pytest.mark.xfail(reason='Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method')
     @pytest.mark.credentials
     def test_that_a_screenshot_can_be_added(self, mozwebqa_devhub_logged_in, free_app):
         """Test the happy path for adding a screenshot for a free submitted app."""
@@ -147,6 +148,7 @@ class TestDeveloperHub(BaseTest):
         Assert.equal(before_screenshots_count + 1, len(edit_listing.screenshots_previews),
                      'Expected %s screenshots, but there are %s.' % (before_screenshots_count + 1, after_screenshots_count))
 
+    @pytest.mark.xfail(reason='Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method')
     @pytest.mark.credentials
     def test_that_a_screenshot_cannot_be_added_via_an_invalid_file_format(self, mozwebqa_devhub_logged_in, free_app):
         """Check that a tiff cannot be successfully uploaded as a screenshot."""
@@ -164,6 +166,7 @@ class TestDeveloperHub(BaseTest):
         Assert.contains('There was an error uploading your file.', screenshot_upload_error_message)
         Assert.contains('Images must be either PNG or JPG.', screenshot_upload_error_message)
 
+    @pytest.mark.xfail(reason='Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method')
     @pytest.mark.credentials
     def test_that_an_icon_cannot_be_added_via_an_invalid_file_format(self, mozwebqa_devhub_logged_in, free_app):
         """Check that a tiff cannot be successfully uploaded as an app icon."""


### PR DESCRIPTION
Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method
https://github.com/mozilla/marketplace-tests/issues/618

Unfortunately it looks like we need to xfail these tests until we find a solution to this problem.

@m8ttyB r?
cc @krupa 