### PR TITLE
Unpin fxapom as we are in full control of it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ chardet==2.1.1
 execnet==1.1
 requests==2.4.3
 Marketplace==0.9.1
-fxapom==1.0
+fxapom


### PR DESCRIPTION


This will mean we won't need to update this project every time fxapom is updated

fxapom was also to pick up a new version of PyFxA, so this project needs to be updated to pick up the new fxapom. I think it makes sense to unpin fxapom as only this project and marketplace-tests-gaia (FxOS tests) use it, and we are in full control of all 3 projects.

@davehunt r?
