### PR TITLE
Update locator for content ratings

### DIFF
--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -28,7 +28,7 @@ class Details(Base):
     _app_dev_username_locator = (By.CSS_SELECTOR, '.author')
     _application_description_locator = (By.CSS_SELECTOR, '.description')
     _image_preview_section_locator = (By.CSS_SELECTOR, '.previews-slider')
-    _content_ratings_button_locator = (By.CSS_SELECTOR, '.content-ratings-wrapper .full .button')
+    _content_ratings_button_locator = (By.CSS_SELECTOR, '.content-ratings-wrapper .content-ratings-button-wrap .button')
     _content_ratings_image_locator = (By.CSS_SELECTOR, '.content-rating img')
     _privacy_policy_locator = (By.CSS_SELECTOR, '#footer a[href*="privacy"]')
     _dots_locator = (By.CSS_SELECTOR, '.dot')


### PR DESCRIPTION
This fixes `test_clicking_on_content_rating` that is currently failing on dev [1] and stage [2].  It will fail on prod until the change is pushed there as well.

@m8ttyB r?

[1] https://webqa-ci.mozilla.com/view/Marketplace/job/marketplace.dev/55/HTML_Report/
[2] https://webqa-ci.mozilla.com/view/Marketplace/job/marketplace.stage.saucelabs/78/HTML_Report/
