### PR TITLE
Move screenshot upload outside of loop

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
+++ b/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
@@ -133,7 +133,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
                 # check/uncheck the checkbox according to the app value
                 app_details.select_categories(*category)
 
-                app_details.screenshot_upload(app['screenshot_link'])
+            app_details.screenshot_upload(app['screenshot_link'])
 
             next_steps = app_details.click_continue()
             Assert.equal('Almost There!', next_steps.almost_there_message)


### PR DESCRIPTION
While investigating a failure I found an error in the code for this test. The line to upload a screenshot was inside a loop whereas it should have been outside the loop. This resulted in multiple screenshots being uploaded which doesn't cause an issue for the test, but is unnecessary and time consuming.

This PR fixes that.

@m8ttyB / @rbillings r?