### PR TITLE
Change the assertion to look for the word 'result' instead of 'results'

### DIFF
--- a/tests/desktop/consumer_pages/test_search.py
+++ b/tests/desktop/consumer_pages/test_search.py
@@ -39,7 +39,7 @@ class TestSearching(BaseTest):
         search_page = home_page.header.search(search_term)
 
         # Check title for the search
-        Assert.contains('results', search_page.search_results_section_title)
+        Assert.contains('result', search_page.search_results_section_title)
 
         # Check that the results contains the search term
         for i in range(len(search_page.results)):


### PR DESCRIPTION
This fixes the failing test `test_that_the_search_tag_is_present_in_the_search_results` which was failing when only one result was found. The old version of the test is asserting that the work `results` should be present, but in fact just the word `result` is sufficient and covers both cases (a single result and multiple results).

The failing test can be seen at https://webqa-ci.mozilla.com/view/Marketplace/job/marketplace.dev/85/testReport/tests.desktop.consumer_pages.test_search/TestSearching/test_that_the_search_tag_is_present_in_the_search_results/

@krupa r?