### PR TITLE
Fixes #645 -  Investigate failure of test_clicking_on_content_rating

### DIFF
--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -168,10 +168,8 @@ class Details(Base):
         self.find_element(*self._content_ratings_button_locator).click()
         return GlobalRatings(self.testsetup)
 
-    @property
-    def is_ratings_image_visible(self):
-        self.scroll_to_element(*self._content_ratings_image_locator)
-        return self.is_element_visible(*self._content_ratings_image_locator)
+    def wait_for_ratings_image_visible(self):
+        self.wait_for_element_visible(*self._content_ratings_image_locator)
 
     class ReportAbuseRegion(PageRegion):
 
@@ -197,7 +195,7 @@ class GlobalRatings(Base):
 
         _page_title = 'IARC Ratings Guide | International Age Rating Coalition'
 
-        _content_ratings_table_locator = (By.CSS_SELECTOR, '.ratings')
+        _content_ratings_table_locator = (By.CSS_SELECTOR, '.ratingsguide')
 
         def __init__(self, testsetup):
             Base.__init__(self, testsetup)

--- a/tests/desktop/consumer_pages/test_details_page.py
+++ b/tests/desktop/consumer_pages/test_details_page.py
@@ -125,7 +125,7 @@ class TestDetailsPage(BaseTest):
         details_page = home_page.header.search_and_click_on_app(search_term)
 
         Assert.true(details_page.is_the_current_page)
-        Assert.true(details_page.is_ratings_image_visible)
+        details_page.wait_for_ratings_image_visible()
 
         # Click on Content Ratings button
         content_ratings_page = details_page.click_content_ratings_button()


### PR DESCRIPTION
Update locator for ratings table
Change is_visible check to a wait_for_visible to address StaleElementReferenceException

This will fix the current failures of `test_clicking_on_content_rating` and should also address the intermittent `StaleElementReferenceException`s

@rbillings / @m8ttyB r?