### PR TITLE
Update locators for mobile tests

### DIFF
--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -82,7 +82,7 @@ class Base(Page):
         _search_suggestions_locator = (By.ID, 'site-search-suggestions')
         _search_suggestion_locator = (By.CSS_SELECTOR, '#site-search-suggestions > div.wrap > ul > li')
         _homepage_back_button_locator = (By.CSS_SELECTOR, '.back-to-marketplace')
-        _back_button_locator = (By.ID, 'nav-back')
+        _back_button_locator = (By.CSS_SELECTOR, '.header-button.back')
         _account_settings_locator = (By.CSS_SELECTOR, '.account-links > a.settings')
         _marketplace_icon_locator = (By.CSS_SELECTOR, '.wordmark')
 

--- a/pages/mobile/details.py
+++ b/pages/mobile/details.py
@@ -15,7 +15,7 @@ class Details(Base):
     _title_locator = (By.CSS_SELECTOR, 'div.info > h3')
     _write_review_locator = (By.CSS_SELECTOR, '.review-button')
     _view_reviews_locator = (By.CSS_SELECTOR, '.review-buttons li:nth-child(2) .button')
-    _product_details_locator = (By.CSS_SELECTOR, '.main.full.app-header.expanded > div')
+    _product_details_locator = (By.CSS_SELECTOR, '.main.full.app-header.previews-expanded > div')
     _app_icon_locator = (By.CSS_SELECTOR, '.product .icon')
     _author_locator = (By.CSS_SELECTOR, '.author')
     _rating_header_locator = (By.CLASS_NAME, 'rating-link')


### PR DESCRIPTION
This fixes the failing tests [1]:

`test_that_after_viewing_reviews_clicking_back_goes_to_app_page`
`test_details_page_for_an_app`
`test_that_checks_the_addition_of_a_review`

@m8ttyB / @rbillings r?

[1] https://webqa-ci.mozilla.com/view/Marketplace/job/marketplace.dev.mobile.saucelabs/133/testReport/