### PR TITLE
Fixes for changes in marketplace-dev nav

### DIFF
--- a/pages/desktop/consumer_pages/account_settings.py
+++ b/pages/desktop/consumer_pages/account_settings.py
@@ -21,6 +21,7 @@ class AccountSettings(Base):
     _header_title_locator = (By.CSS_SELECTOR, 'header.c > h1')
     _payment_page_locator = (By.ID, 'purchases')
     _settings_sign_in_locator = (By.CSS_SELECTOR, '.account-settings-save a:not(.register)')
+    _settings_sign_out_locator = (By.CSS_SELECTOR, '.account-settings-save .logout')
 
     def go_to_settings_page(self):
         self.set_window_size()
@@ -38,8 +39,11 @@ class AccountSettings(Base):
     def wait_for_page_loaded(self):
         WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_present(*self._payment_page_locator))
 
-    def click_account_settings_sign_in(self):
+    def click_sign_in(self):
         self.find_element(*self._settings_sign_in_locator).click()
+
+    def click_sign_out(self):
+        self.find_element(*self._settings_sign_out_locator).click()
 
 
 class BasicInfo(AccountSettings):

--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -15,14 +14,15 @@ class Home(Base):
 
     _page_title = 'Firefox Marketplace'
 
-    _site_navigation_menu_locator = (By.CSS_SELECTOR, '.navbar')
-    _category_menu_locator = (By.CSS_SELECTOR, '.tab-categories')
+    _site_navigation_menu_locator = (By.CSS_SELECTOR, 'mkt-header-nav')
+    _category_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[title="Categories"]')
+    _category_list_locator = (By.TAG_NAME, 'mkt-category-list')
     _category_count_locator = (By.CSS_SELECTOR, '.cat-overlay li')
     _item_locator = (By.CSS_SELECTOR, '.app-list-app')
     _categories_tabel_locator = (By.CSS_SELECTOR, '.cat-overlay')
     _first_new_app_name_locator = (By.CSS_SELECTOR, '.info > h3')
-    _new_tab_menu_locator = (By.CSS_SELECTOR, '.tab-link[href*=new]')
-    _popular_tab_menu_locator = (By.CSS_SELECTOR, '.tab-link[href*=popular]')
+    _new_tab_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[href*=new]')
+    _popular_tab_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[href*=popular]')
     _feed_title_locator = (By.CSS_SELECTOR, '.subheader > h1')
     _promo_box_locator = (By.CSS_SELECTOR, '.desktop-promo')
     _promo_box_items_locator = (By.CSS_SELECTOR, '.desktop-promo-item')
@@ -46,10 +46,11 @@ class Home(Base):
     def category_menu_text(self):
         return self.selenium.find_element(*self._category_menu_locator).text
 
-    def hover_over_categories_menu(self):
-        while self.is_element_not_visible(*self._categories_tabel_locator):
-            hover_element = self.selenium.find_element(*self._category_menu_locator)
-            ActionChains(self.selenium).move_to_element(hover_element).perform()
+    def open_categories_menu(self):
+        category_list = self.selenium.find_element(*self._category_list_locator)
+        if not category_list.is_displayed():
+            self.selenium.find_element(*self._category_menu_locator).click()
+            WebDriverWait(self.selenium, self.timeout).until(lambda s: category_list.is_displayed())
 
     @property
     def categories(self):

--- a/pages/desktop/regions/categories.py
+++ b/pages/desktop/regions/categories.py
@@ -12,8 +12,8 @@ from pages.page import Page, PageRegion
 
 class CategoriesSection(Page):
 
-    _category_menu_locator = (By.CSS_SELECTOR, '.desktop-cat-link')
-    _category_item_locator = (By.CSS_SELECTOR, '.hovercats li')
+    _category_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[title="Categories"]')
+    _category_item_locator = (By.CSS_SELECTOR, '#header--categories mkt-category-item')
 
     @property
     def title(self):
@@ -30,12 +30,11 @@ class CategoriesSection(Page):
 
     class CategoryItem(PageRegion):
 
-        _category_name_locator = (By.CSS_SELECTOR, '.tab-categories li a')
-        _category_link_locator = (By.CSS_SELECTOR, 'a')
+        _category_link_locator = (By.CSS_SELECTOR, '.mkt-category-link')
 
         @property
         def name(self):
-            return self.find_element(*self._category_name_locator).text
+            return self.find_element(*self._category_link_locator).text
 
         @property
         def link_to_category_page(self):
@@ -43,7 +42,6 @@ class CategoriesSection(Page):
 
         def click_category(self):
             category_name = self.name
-            self.wait_for_element_visible(*self._category_link_locator)
             self.find_element(*self._category_link_locator).click()
             from pages.desktop.consumer_pages.category import Category
             return Category(self.testsetup, category_name)

--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -34,7 +34,7 @@ class TestConsumerPage(BaseTest):
 
         Assert.true(home_page.header.is_logo_visible)
         Assert.true(home_page.header.is_search_visible)
-        Assert.equal(home_page.header.search_field_placeholder, "Search the Marketplace")
+        Assert.equal(home_page.header.search_field_placeholder, u'Search Marketplace\u2026')
         Assert.true(home_page.header.is_sign_in_visible)
 
     @pytest.mark.sanity
@@ -44,10 +44,9 @@ class TestConsumerPage(BaseTest):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        Assert.equal(home_page.categories.title, 'Categories'.upper())
+        Assert.equal(home_page.categories.title, 'Categories')
 
-        # Hover over "Categories" menu
-        home_page.hover_over_categories_menu()
+        home_page.open_categories_menu()
         Assert.greater(len(home_page.categories.items), 0)
 
     @pytest.mark.sanity
@@ -61,7 +60,7 @@ class TestConsumerPage(BaseTest):
         categories = home_page.categories.items
         # only check the first three categories
         for c in range(3):
-            home_page.hover_over_categories_menu()
+            home_page.open_categories_menu()
             category = categories[c]
             category_name = category.name
             category_page = category.click_category()

--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -28,7 +28,7 @@ class TestAccounts(BaseTest):
         Assert.false(home_page.header.is_sign_in_visible)
         Assert.true(home_page.is_the_current_page)
 
-        home_page.header.hover_over_settings_menu()
+        home_page.header.open_settings_menu()
         Assert.true(home_page.header.is_user_logged_in)
 
     @pytest.mark.sanity
@@ -57,7 +57,7 @@ class TestAccounts(BaseTest):
         settings_page = My_Apps(mozwebqa)
         settings_page.go_to_my_apps_page()
 
-        settings_page.click_account_settings_sign_in()
+        settings_page.click_sign_in()
         acct = self.create_new_user(mozwebqa)
         settings_page.login(acct)
 
@@ -74,14 +74,14 @@ class TestAccounts(BaseTest):
         settings_page = AccountSettings(mozwebqa)
         settings_page.go_to_settings_page()
 
-        settings_page.click_account_settings_sign_in()
+        settings_page.click_sign_in()
         acct = self.create_new_user(mozwebqa)
         settings_page.login(acct)
 
         Assert.true(settings_page.header.is_user_logged_in)
         Assert.false(settings_page.header.is_sign_in_visible)
 
-        settings_page.header.click_sign_out()
+        settings_page.click_sign_out()
         Assert.true(settings_page.header.is_sign_in_visible)
 
     @pytest.mark.credentials


### PR DESCRIPTION
This fixes a large number of failing tests on dev and stage, which are failing due to a new nav being implemented.

Specifically, this should allow all the tests in `tests/desktop/consumer_pages/test_home_page.py` and `tests/desktop/consumer_pages/test_details_page.py` to pass.

I will put together another PR for the other failing tests.

@krupa We need to decide whether to merge these changes to the `master` branch, in which case prod will fail until this new nav is implemented on prod, or whether we need to have a new branch to use for just testing dev and stage. How long will it be before the changes make it to prod?

@m8ttyB / @rbillings r?
