### PR TITLE
Update locator for email field on settings page

### DIFF
--- a/pages/desktop/consumer_pages/account_settings.py
+++ b/pages/desktop/consumer_pages/account_settings.py
@@ -54,7 +54,7 @@ class BasicInfo(AccountSettings):
 
     _page_title = 'Account Settings | Firefox Marketplace'
 
-    _email_locator = (By.CSS_SELECTOR, '.email p')
+    _email_locator = (By.CSS_SELECTOR, '.settings-email.account-field > p')
     _display_name_input_locator = (By.ID, 'display_name')
     _save_button_locator = (By.CSS_SELECTOR, '.button[type="submit"]')
     _multiple_language_select_locator = (By.ID, 'language')


### PR DESCRIPTION
This fixes the failure as seen at https://webqa-ci.mozilla.com/view/Marketplace/job/marketplace.dev.sanity.saucelabs/99/testReport/tests.desktop.consumer_pages.test_home_page/TestConsumerPage/test_settings_dropdown_menu/

Unfortunately this test will still fail, but at a different place, for a different reason, which I am discussing with @krupa.

@m8ttyB r? 