### PR TITLE
Fixes Issue #655 - Marketplace desktop review tests are failing

### DIFF
--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -62,7 +62,7 @@ class Home(Base):
         return len(self.selenium.find_elements(*self._category_count_locator))
 
     @property
-    def first_new_app_name(self):
+    def first_app_name(self):
         return self.find_element(*self._first_new_app_name_locator).text
 
     @property

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -71,13 +71,13 @@ class BaseTest:
 
         return payment_settings_page
 
-    def _take_first_new_app_name(self, mozwebqa):
+    def _take_first_free_app_name(self, mozwebqa):
 
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        home_page.click_popular_tab()
-        app_name = home_page.first_new_app_name
+        home_page.header.search(':free')
+        app_name = home_page.first_app_name
         return app_name
 
     def create_new_user(self, mozwebqa):

--- a/tests/desktop/consumer_pages/test_details_page.py
+++ b/tests/desktop/consumer_pages/test_details_page.py
@@ -23,7 +23,7 @@ class TestDetailsPage(BaseTest):
 
         Assert.true(home_page.is_the_current_page)
 
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         details_page = home_page.header.search_and_click_on_app(search_term)
 
         Assert.true(details_page.is_the_current_page)
@@ -64,7 +64,7 @@ class TestDetailsPage(BaseTest):
 
         Assert.true(home_page.is_the_current_page)
 
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         details_page = home_page.header.search_and_click_on_app(search_term)
 
         Assert.true(details_page.is_the_current_page)
@@ -94,7 +94,7 @@ class TestDetailsPage(BaseTest):
         home_page.login(acct)
         Assert.true(home_page.header.is_user_logged_in)
 
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         details_page = home_page.header.search_and_click_on_app(search_term)
 
         Assert.true(details_page.is_the_current_page)
@@ -121,7 +121,7 @@ class TestDetailsPage(BaseTest):
         Assert.true(home_page.is_the_current_page)
 
         home_page.set_region("restofworld")
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         details_page = home_page.header.search_and_click_on_app(search_term)
 
         Assert.true(details_page.is_the_current_page)

--- a/tests/desktop/consumer_pages/test_reviews.py
+++ b/tests/desktop/consumer_pages/test_reviews.py
@@ -29,7 +29,7 @@ class TestReviews(BaseTest):
         Assert.true(home_page.is_the_current_page)
 
         # Step 2 - Search for the test app and go to its details page
-        app_name = self._take_first_new_app_name(mozwebqa)
+        app_name = self._take_first_free_app_name(mozwebqa)
         details_page = home_page.header.search_and_click_on_app(app_name)
         Assert.true(details_page.is_the_current_page)
 
@@ -68,7 +68,7 @@ class TestReviews(BaseTest):
         Assert.true(home_page.is_the_current_page)
 
         # Search for the test app and go to its details page
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         details_page = home_page.header.search_and_click_on_app(search_term)
         Assert.true(details_page.is_the_current_page)
         Assert.equal(details_page.review_button_text, "Sign in to review")

--- a/tests/desktop/consumer_pages/test_search.py
+++ b/tests/desktop/consumer_pages/test_search.py
@@ -35,7 +35,7 @@ class TestSearching(BaseTest):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         search_page = home_page.header.search(search_term)
 
         # Check title for the search
@@ -72,7 +72,7 @@ class TestSearching(BaseTest):
 
         Assert.true(home_page.is_the_current_page)
 
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
 
         home_page.header.type_search_term_in_search_field(search_term)
         Assert.true(home_page.header.is_search_suggestion_list_visible)
@@ -99,7 +99,7 @@ class TestSearching(BaseTest):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
 
-        search_term = self._take_first_new_app_name(mozwebqa)
+        search_term = self._take_first_free_app_name(mozwebqa)
         search_page = home_page.header.search(search_term)
 
         search_page.click_expand_button()


### PR DESCRIPTION
Make sure we use a free app when testing reviews

The review tests were failing (e.g. [1]) because we were using a paid app, and a user cannot write a review for a paid app unless they have purchased it.

This PR fixes that, and in fact causes all of our tests to use a free app by default, which is desirable.

@rbillings / @m8ttyB r?

[1] https://webqa-ci.mozilla.com/job/marketplace.dev.saucelabs/137/testReport/tests.desktop.consumer_pages.test_reviews/TestReviews/test_that_checks_the_addition_of_a_review/