### PR TITLE
Update set_region() method to use search field correctly

### DIFF
--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -51,10 +51,7 @@ class Base(Page):
         self.wait_for_element_not_visible(*self._notification_locator)
 
     def go_to_debug_page(self):
-
-        search_field = self.selenium.find_element(*self._search_locator)
-        search_field.send_keys(":debug")
-        search_field.submit()
+        self.header.search(':debug')
         from pages.desktop.regions.debug import Debug
         return Debug(self.testsetup)
 


### PR DESCRIPTION
This fixes the failing test `test_clicking_on_content_rating` which was attempting to `send_keys` to a field that is not visible.

Failure can be seen at https://webqa-ci.mozilla.com/job/marketplace.dev/112/testReport/tests.desktop.consumer_pages.test_details_page/TestDetailsPage/test_clicking_on_content_rating/

@rbillings / @m8ttyB r?