### PR TITLE
Another test needs to be xfailed for Bug 1154123 - Screenshot thumbnail does not appear on Edit Listing page

### DIFF
--- a/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
+++ b/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
@@ -235,6 +235,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
             delete_popup = edit_app.click_delete_app()
             delete_popup.delete_app()
 
+    @pytest.mark.xfail(reason='Bug 1154123 - Screenshot thumbnail does not appear on Edit Listing page')
     @pytest.mark.credentials
     def test_check_submission_of_an_app_with_XSS_in_its_app_name(self, mozwebqa_devhub_logged_in):
         if '-dev.allizom' in mozwebqa_devhub_logged_in.base_url:


### PR DESCRIPTION
I missed one because the test results were misleading, but it is failing for the same reason as the others.