### PR TITLE
Remove conditional wait for page to load

### DIFF
--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -40,11 +40,10 @@ class Details(Base):
     _report_abuse_button_locator = (By.CSS_SELECTOR, '.button.abuse')
     _report_abuse_box_locator = (By.CSS_SELECTOR, '.abuse-form')
 
-    def __init__(self, testsetup, app_name=False, first_access=False):
+    def __init__(self, testsetup, app_name=None):
         Base.__init__(self, testsetup)
-        if first_access:
-            self.wait_for_page_to_load()
-        if app_name:
+        self.wait_for_page_to_load()
+        if app_name is not None:
             self._page_title = "%s | Firefox Marketplace" % app_name
             self.app_name = app_name
         else:

--- a/pages/desktop/consumer_pages/search.py
+++ b/pages/desktop/consumer_pages/search.py
@@ -88,4 +88,4 @@ class Search(Base, Sorter, Filter):
             name = self.name
             self.find_element(*self._name_locator).click()
             from pages.desktop.consumer_pages.details import Details
-            return Details(self.testsetup, name, first_access=True)
+            return Details(self.testsetup, name)


### PR DESCRIPTION
This fixes the failures by always waiting for the page to load. The links below are only available via the Mozilla VPN.

Without patch (3 failures):
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/3/testReport/

With patch (0 failures):
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/4/testReport/

Full run with patch (0 failures):
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/6/testReport/

Pinging any of @bobsilverberg @krupa @AndreiH or @bebef1987 for review. :)