### PR TITLE
Improve wait for notification messages. Fixes issue #663

### DIFF
--- a/pages/desktop/consumer_pages/add_review.py
+++ b/pages/desktop/consumer_pages/add_review.py
@@ -29,6 +29,7 @@ class AddReview(Base):
         self.set_review_rating(rating)
         self.enter_review_with_text(body)
         self.selenium.find_element(*self._submit_review_button_locator).click()
+        self.wait_for_notification('Your review was successfully posted. Thanks!')
         from pages.desktop.consumer_pages.details import Details
         return Details(self.testsetup)
 

--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -40,15 +40,15 @@ class Details(Base):
     _report_abuse_button_locator = (By.CSS_SELECTOR, '.button.abuse')
     _report_abuse_box_locator = (By.CSS_SELECTOR, '.abuse-form')
 
-    def __init__(self, testsetup, app_name=False, first_access=False):
+    def __init__(self, testsetup, app_name=None):
         Base.__init__(self, testsetup)
-        if first_access:
-            self.wait_for_page_to_load()
-        if app_name:
-            self._page_title = "%s | Firefox Marketplace" % app_name
-            self.app_name = app_name
-        else:
-            self._page_title = "%s | Firefox Marketplace" % self.title
+        self.wait_for_page_to_load()
+        self.app_name = app_name
+
+    @property
+    def _page_title(self):
+        app_name = self.app_name or self.title
+        return '%s | Firefox Marketplace' % app_name
 
     @property
     def title(self):

--- a/pages/desktop/consumer_pages/edit_review.py
+++ b/pages/desktop/consumer_pages/edit_review.py
@@ -34,5 +34,6 @@ class EditReview(Base):
         self.delete_review()
         self.enter_review_with_text(body)
         self.selenium.find_element(*self._submit_review_button_locator).click()
+        self.wait_for_notification('Your review was successfully edited')
         from pages.desktop.consumer_pages.details import Details
         return Details(self.testsetup)

--- a/pages/desktop/consumer_pages/reviews.py
+++ b/pages/desktop/consumer_pages/reviews.py
@@ -18,11 +18,14 @@ class Reviews(Base):
 
     _review_locator = (By.CSS_SELECTOR, '.review')
 
-    def __init__(self, testsetup, app_name=False):
+    def __init__(self, testsetup, app_name=None):
         Base.__init__(self, testsetup)
         self.wait_for_page_to_load()
-        if app_name:
-            self._page_title = "Reviews for %s | Firefox Marketplace" % app_name
+        self.app_name = app_name
+
+    @property
+    def _page_title(self):
+        return 'Reviews for %s | Firefox Marketplace' % self.app_name
 
     @property
     def reviews(self):

--- a/pages/desktop/consumer_pages/search.py
+++ b/pages/desktop/consumer_pages/search.py
@@ -24,14 +24,14 @@ class Search(Base, Sorter, Filter):
     _applied_filters_locator = (By.CSS_SELECTOR, '.applied-filters > ol > li > a')
     _search_results_section_title_locator = (By.CSS_SELECTOR, '.search-results-header-desktop')
 
-    def __init__(self, testsetup, app_name=False):
+    def __init__(self, testsetup, app_name=None):
         Base.__init__(self, testsetup)
         Sorter.__init__(self, testsetup)
-        if app_name:
-            self._page_title = '%s | Firefox Marketplace' % app_name
-            self.app_name = app_name
-        else:
-            self._page_title = 'Search Results | Firefox Marketplace'
+        self.app_name = app_name
+
+    @property
+    def _page_title(self):
+        return '%s | Firefox Marketplace' % (self.app_name or 'Search Results')
 
     @property
     def applied_filters(self):
@@ -88,4 +88,4 @@ class Search(Base, Sorter, Filter):
             name = self.name
             self.find_element(*self._name_locator).click()
             from pages.desktop.consumer_pages.details import Details
-            return Details(self.testsetup, name, first_access=True)
+            return Details(self.testsetup, name)

--- a/tests/desktop/consumer_pages/test_details_page.py
+++ b/tests/desktop/consumer_pages/test_details_page.py
@@ -78,9 +78,7 @@ class TestDetailsPage(BaseTest):
         Assert.true(report_abuse_box.is_report_button_enabled)
 
         report_abuse_box.click_report_button()
-
-        details_page.wait_notification_box_visible()
-        Assert.equal(details_page.notification_message, "Abuse report submitted. Thanks!")
+        details_page.wait_for_notification('Abuse report submitted. Thanks!')
 
     @pytest.mark.credentials
     def test_that_reports_abuse_as_signed_in_user(self, mozwebqa):
@@ -108,9 +106,7 @@ class TestDetailsPage(BaseTest):
         Assert.true(report_abuse_box.is_report_button_enabled)
 
         report_abuse_box.click_report_button()
-
-        details_page.wait_notification_box_visible()
-        Assert.equal(details_page.notification_message, "Abuse report submitted. Thanks!")
+        details_page.wait_for_notification('Abuse report submitted. Thanks!')
 
     @pytest.mark.nondestructive
     def test_clicking_on_content_rating(self, mozwebqa):

--- a/tests/desktop/consumer_pages/test_reviews.py
+++ b/tests/desktop/consumer_pages/test_reviews.py
@@ -41,10 +41,6 @@ class TestReviews(BaseTest):
         details_page = add_review_box.write_a_review(mock_review['rating'], mock_review['body'])
 
         # Step 4 - Check review
-        details_page.wait_notification_box_visible()
-        Assert.equal(details_page.notification_message, "Your review was successfully posted. Thanks!")
-        details_page.wait_notification_box_not_visible()
-
         Assert.equal(details_page.first_review_rating, mock_review['rating'])
         Assert.equal(details_page.first_review_body, mock_review['body'])
 
@@ -79,9 +75,6 @@ class TestReviews(BaseTest):
         details_page.login(acct)
 
         add_review_box.write_a_review(mock_review['rating'], mock_review['body'])
-        details_page.wait_notification_box_visible()
-        details_page.wait_notification_box_not_visible()
-
         Assert.equal(details_page.first_review_rating, mock_review['rating'])
         Assert.equal(details_page.first_review_body, mock_review['body'])
 
@@ -105,11 +98,6 @@ class TestReviews(BaseTest):
         edit_review = details_page.click_review_button(edit_review=True)
         mock_review = MockReview()
         details_page = edit_review.write_a_review(mock_review['rating'], mock_review['body'])
-
-        # Check notification
-        details_page.wait_notification_box_visible()
-        Assert.equal(details_page.notification_message, "Your review was successfully edited")
-        details_page.wait_notification_box_not_visible()
 
         # Go to reviews page and verify
         reviews_page = details_page.click_all_reviews_button()
@@ -137,9 +125,6 @@ class TestReviews(BaseTest):
 
         review = reviews_page.get_review_for_user(user_name)
         review.delete()
-        reviews_page.wait_notification_box_visible()
-
-        Assert.equal(reviews_page.notification_message,
-                     "This review has been successfully deleted")
-        reviews_page.wait_notification_box_not_visible()
+        details_page.wait_for_notification(
+            'This review has been successfully deleted')
         Assert.false(reviews_page.is_review_for_user_present(user_name))

--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -104,8 +104,7 @@ class TestAccounts(BaseTest):
 
         profile_page.edit_display_name(name)
         profile_page.save_changes()
-        profile_page.wait_notification_box_visible()
-        Assert.equal(profile_page.notification_message, 'Your settings have been successfully saved')
+        profile_page.wait_for_notification('Your settings have been successfully saved')
 
         # Refresh page and then inspect saved settings
         profile_page.refresh_page()


### PR DESCRIPTION
This patch improves the waiting for notifications with optional messages. It also constructs the expected page titles outside of the page object initialization. It replaces #664.

Passing builds for dev:
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/9/testReport/
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/10/testReport/

Passing builds for staging:
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/11/testReport/
http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/12/testReport/

Pinging @bobsilverberg, @krupa, @AndreiH, and @bebef1987 for review. :smile: