### PR TITLE
Fix locators

### DIFF
--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -138,6 +138,7 @@ class Base(Page):
             for i in range(len(results)):
                 if search_term == results[i].name:
                     return results[i].click_name()
+            raise Exception('No application named %s could be found.' % search_term)
 
         def type_search_term_in_search_field(self, search_term):
             search_field = self.selenium.find_element(*self._search_locator)

--- a/pages/desktop/consumer_pages/details.py
+++ b/pages/desktop/consumer_pages/details.py
@@ -19,8 +19,8 @@ class Details(Base):
 
     _title_locator = (By.CSS_SELECTOR, '.info > h3')
     _install_purchased_locator = (By.CSS_SELECTOR, 'section.product-details > div.actions > a.premium.purchased.installing')
-    _install_locator = (By.CSS_SELECTOR, '.button.product.install')
-    _image_locator = (By.CSS_SELECTOR, '.product.mkt-tile .heading .icon')
+    _install_locator = (By.CSS_SELECTOR, '.button.mkt-app-button.install')
+    _image_locator = (By.CSS_SELECTOR, '.mkt-tile .mkt-app-heading .icon')
     _name_locator = (By.CSS_SELECTOR, '.info > h3')
     _support_email_locator = (By.CSS_SELECTOR, '.support-email > a')
     _app_site_locator = (By.CSS_SELECTOR, '.support-url > a')
@@ -38,7 +38,7 @@ class Details(Base):
     _reviews_button_locator = (By.CSS_SELECTOR, '.review-buttons li:nth-child(2) .button')
     _report_abuse_button_locator = (By.CSS_SELECTOR, '.button.abuse')
     _report_abuse_box_locator = (By.CSS_SELECTOR, '.abuse-form')
-    _app_price_locator = (By.CSS_SELECTOR, '.button.product.install > em')
+    _app_price_locator = (By.CSS_SELECTOR, '.button.mkt-app-button.install > em')
 
     def __init__(self, testsetup, app_name=None):
         Base.__init__(self, testsetup)

--- a/pages/desktop/consumer_pages/search.py
+++ b/pages/desktop/consumer_pages/search.py
@@ -53,7 +53,7 @@ class Search(Base, Sorter, Filter):
         """provides the methods to access a search result
         self._root_element - webelement that points to a single result"""
 
-        _screenshots_locator = (By.CSS_SELECTOR, '.screenshot')
+        _screenshots_locator = (By.CSS_SELECTOR, '.previews-thumbnail')
         _install_button_locator = (By.CSS_SELECTOR, '.button.install')
         _rating_locator = (By.CSS_SELECTOR, '.stars')
         _icon_locator = (By.CSS_SELECTOR, '.icon')

--- a/tests/desktop/consumer_pages/test_search.py
+++ b/tests/desktop/consumer_pages/test_search.py
@@ -104,7 +104,8 @@ class TestSearching(BaseTest):
 
         search_page.click_expand_button()
 
-        for i in range(len(search_page.results)):
+        # check the first 5 results
+        for i in range(min(len(search_page.results), 5)):
             Assert.true(search_page.results[i].is_install_button_visible)
             Assert.true(search_page.results[i].is_icon_visible)
             Assert.true(search_page.results[i].is_rating_visible)


### PR DESCRIPTION
Two tests are failing because of changed locators [1]:
`test_that_application_page_contains_proper_objects`
`test_results_page_items`

This PR fixes those and also introduces a couple of small test improvements that I found while testing.

Note that this does not fix `test_that_user_can_purchase_an_app`. That will be fixed in a separate PR.

[1] https://webqa-ci.mozilla.com/job/marketplace.dev/157/HTML_Report/