### PR TITLE
Fix mobile test failures

### DIFF
--- a/pages/mobile/details.py
+++ b/pages/mobile/details.py
@@ -13,11 +13,11 @@ from pages.mobile.base import Base
 
 class Details(Base):
 
-    _title_locator = (By.CSS_SELECTOR, 'div.info > h3')
+    _title_locator = (By.CSS_SELECTOR, '.mkt-tile-info > h3')
     _write_review_locator = (By.CSS_SELECTOR, '.review-button')
     _view_reviews_locator = (By.CSS_SELECTOR, '.review-buttons li:nth-child(2) .button')
     _product_details_locator = (By.CSS_SELECTOR, '.main.full.app-header.previews-expanded > div')
-    _app_icon_locator = (By.CSS_SELECTOR, '.product .icon')
+    _app_icon_locator = (By.CSS_SELECTOR, '.mkt-tile .icon')
     _author_locator = (By.CSS_SELECTOR, '.author')
     _rating_header_locator = (By.CLASS_NAME, 'rating-link')
     _app_description_locator = (By.CLASS_NAME, 'description')

--- a/pages/mobile/search.py
+++ b/pages/mobile/search.py
@@ -13,7 +13,7 @@ from pages.mobile.base import Base
 
 class Search(Base):
 
-    _result_locator = (By.CSS_SELECTOR, '.product .info')
+    _result_locator = (By.CSS_SELECTOR, '#search-results .item.result')
     _no_results_locator = (By.CSS_SELECTOR, '.no-results')
 
     @property
@@ -28,7 +28,7 @@ class Search(Base):
 
     class Result(PageRegion):
 
-        _name_locator = (By.CSS_SELECTOR, "div.info > h3")
+        _name_locator = (By.CSS_SELECTOR, ".mkt-tile-info > h3")
 
         @property
         def name(self):


### PR DESCRIPTION
This fixes #675 

Changes include:

Update locators for mobile page objects
Use a specific app that is guaranteed to have all optional fields for test_reviews_section
Un-xfail test_reviews_section

Current failures can be seen at https://webqa-ci.mozilla.com/view/Buildmaster/job/marketplace.dev.mobile.saucelabs/219/
