### PR TITLE
Fix changed locator for back button

### DIFF
--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -107,7 +107,7 @@ class Header(Page):
 
     _search_toggle_locator = (By.CSS_SELECTOR, '.header--search-toggle')
     _search_input_locator = (By.ID, 'search-q')
-    _back_button_locator = (By.CSS_SELECTOR, '.header-button.back')
+    _back_button_locator = (By.CSS_SELECTOR, '.hamburger')
     _marketplace_icon_locator = (By.CSS_SELECTOR, '.wordmark')
 
     def search(self, search_term):

--- a/tests/mobile/test_search.py
+++ b/tests/mobile/test_search.py
@@ -28,6 +28,7 @@ class TestSearch():
 
         details_page = home_page.go_to_first_free_app_page()
         search_term = details_page.title
+        details_page.header.click_back()
         search_page = home_page.header.search(search_term)
 
         results = search_page.results()
@@ -36,7 +37,9 @@ class TestSearch():
         # Check that the results contains the search term
         for i in range(len(results)):
             if search_term == results[i].name:
-                Assert.equal(search_term, results[i].name)
+                return
+
+        Assert.fail('The search results did not include the app: %s' % search_term)
 
     @pytest.mark.nondestructive
     def test_searching_with_no_matching_results(self, mozwebqa):


### PR DESCRIPTION
Search no longer possible from app details, so add a step to click back before searching

This fixes the four failing tests as seen at https://webqa-ci.mozilla.com/job/marketplace.dev.mobile.saucelabs/231/

@m8ttyB r?