### PR TITLE
Pin the version of fxapom that we use to allow us to migrate to new versions in a controlled fashion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ chardet==2.1.1
 execnet==1.1
 requests==2.4.3
 Marketplace==0.9.1
-fxapom
+fxapom==1.2


### PR DESCRIPTION
We are going to be deploying a new version of `fxapom` which breaks backwards compatibility. In order to be able to update this suite in a controlled fashion, I am pinning to the current version of `fxapom` [1].

[1] https://pypi.python.org/pypi/fxapom