### PR TITLE
Fixes #674 - Update paid app submission test to add a payment account

### DIFF
--- a/pages/desktop/developer_hub/compatibility_and_payments.py
+++ b/pages/desktop/developer_hub/compatibility_and_payments.py
@@ -17,11 +17,34 @@ class CompatibilityAndPayments(Base):
     _device_types_error_locator = (By.CSS_SELECTOR, '.free.tab.active > .error')
     _save_changes_locator = (By.CSS_SELECTOR, '#compat-save-button > button')
 
-    _price_drop_down_locator = (By.ID, 'id_price')
     _payment_accounts_drop_down_locator = (By.ID, 'id_form-0-accounts')
+    _payment_account_action_link_locator = (By.ID, 'payment-account-action')
+    _add_payment_account_button_locator = (By.CSS_SELECTOR, '.add-payment-account.button')
+    _payment_account_account_name_input_locator = (By.ID, 'id_account_name')
+    _payment_account_name_input_locator = (By.ID, 'id_name')
+    _payment_account_email_input_locator = (By.ID, 'id_email')
+    _register_payment_account_button_locator = (By.CSS_SELECTOR, '#payment-account-add button')
+    _agree_to_the_terms_button_locator = (By.CSS_SELECTOR, '#show-agreement button')
+
+    _price_drop_down_locator = (By.ID, 'id_price')
     _price_section_locator = (By.CSS_SELECTOR, 'section#regions')
     _save_payments_changes_locator = (By.CSS_SELECTOR, '#paid-regions-island .listing-footer > button')
     _changes_saved_notification_locator = (By.CSS_SELECTOR, '.notification-box.success')
+
+    def add_payment_account(self):
+        self.selenium.find_element(*self._payment_account_action_link_locator).click()
+        self.wait_for_element_visible(*self._add_payment_account_button_locator)
+        self.selenium.find_element(*self._add_payment_account_button_locator).click()
+        self.wait_for_element_visible(*self._payment_account_account_name_input_locator)
+        self.selenium.find_element(
+            *self._payment_account_account_name_input_locator).send_keys('Test account name')
+        self.selenium.find_element(
+            *self._payment_account_name_input_locator).send_keys('Test name')
+        self.selenium.find_element(
+            *self._payment_account_email_input_locator).send_keys('test_email@mozilla.com')
+        self.selenium.find_element(*self._register_payment_account_button_locator).click()
+        self.wait_for_element_visible(*self._agree_to_the_terms_button_locator)
+        self.selenium.find_element(*self._agree_to_the_terms_button_locator).click()
 
     def clear_device_types(self):
         """Sets all device type checkboxes to unchecked"""

--- a/tests/desktop/developer_hub/conftest.py
+++ b/tests/desktop/developer_hub/conftest.py
@@ -6,8 +6,16 @@ import pytest
 
 
 @pytest.fixture
-def login(mozwebqa, existing_user):
+def login_existing(mozwebqa, existing_user):
     from pages.desktop.developer_hub.home import Home
     home_page = Home(mozwebqa)
     home_page.go_to_developers_homepage()
     home_page.login(mozwebqa, existing_user['email'], existing_user['password'])
+
+
+@pytest.fixture
+def login_new(mozwebqa, new_user):
+    from pages.desktop.developer_hub.home import Home
+    home_page = Home(mozwebqa)
+    home_page.go_to_developers_homepage()
+    home_page.login(mozwebqa, new_user['email'], new_user['password'])

--- a/tests/desktop/developer_hub/test_api_submit.py
+++ b/tests/desktop/developer_hub/test_api_submit.py
@@ -13,7 +13,7 @@ from tests.base_test import BaseTest
 class TestAPI(BaseTest):
 
     @pytest.mark.credentials
-    def test_assert_that_an_app_can_be_added_and_deleted_via_the_api(self, api, mozwebqa, login):
+    def test_assert_that_an_app_can_be_added_and_deleted_via_the_api(self, api, mozwebqa, login_existing):
         mock_app = MockApplication()  # generate mock app
         api.submit_app(mock_app)  # submit app
         app_status = api.app_status(mock_app)  # get app data from API

--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -20,7 +20,7 @@ class TestDeveloperHub(BaseTest):
         return edit_listing_page
 
     @pytest.mark.credentials
-    def test_that_deletes_app(self, mozwebqa, login, free_app):
+    def test_that_deletes_app(self, mozwebqa, login_existing, free_app):
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
         app_status_page = edit_listing.left_nav_menu.click_status()
         delete_popup = app_status_page.click_delete_app()
@@ -40,7 +40,7 @@ class TestDeveloperHub(BaseTest):
                     my_apps.paginator.click_next_page()
 
     @pytest.mark.credentials
-    def test_that_checks_editing_basic_info_for_a_free_app(self, mozwebqa, login, free_app):
+    def test_that_checks_editing_basic_info_for_a_free_app(self, mozwebqa, login_existing, free_app):
         """Test the happy path for editing the basic information for a free submitted app."""
 
         updated_app = MockApplication(
@@ -69,7 +69,7 @@ class TestDeveloperHub(BaseTest):
         Assert.equal(edit_listing.categories.sort(), updated_app['categories'].sort())
 
     @pytest.mark.credentials
-    def test_that_checks_editing_support_information_for_a_free_app(self, mozwebqa, login, free_app):
+    def test_that_checks_editing_support_information_for_a_free_app(self, mozwebqa, login_existing, free_app):
         updated_app = MockApplication()
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
 
@@ -85,7 +85,7 @@ class TestDeveloperHub(BaseTest):
         Assert.equal(edit_listing.website, updated_app['support_website'])
 
     @pytest.mark.credentials
-    def test_that_checks_required_field_validations_on_basic_info_for_a_free_app(self, mozwebqa, login, free_app):
+    def test_that_checks_required_field_validations_on_basic_info_for_a_free_app(self, mozwebqa, login_existing, free_app):
         """Ensure that all required fields generate warning messages and prevent form submission."""
 
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
@@ -107,7 +107,7 @@ class TestDeveloperHub(BaseTest):
         basic_info_region.click_cancel()
 
     @pytest.mark.credentials
-    def test_that_checks_required_field_validations_on_device_types_for_hosted_apps(self, mozwebqa, login, free_app):
+    def test_that_checks_required_field_validations_on_device_types_for_hosted_apps(self, mozwebqa, login_existing, free_app):
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
         compatibility_page = edit_listing.left_nav_menu.click_compatibility_and_payments()
         compatibility_page.clear_device_types()
@@ -115,7 +115,7 @@ class TestDeveloperHub(BaseTest):
         Assert.contains('Please select a device.', compatibility_page.device_types_error_message)
 
     @pytest.mark.credentials
-    def test_that_a_screenshot_can_be_added(self, mozwebqa, login, free_app):
+    def test_that_a_screenshot_can_be_added(self, mozwebqa, login_existing, free_app):
         """Test the happy path for adding a screenshot for a free submitted app."""
 
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
@@ -142,7 +142,7 @@ class TestDeveloperHub(BaseTest):
                      'Expected %s screenshots, but there are %s.' % (before_screenshots_count + 1, after_screenshots_count))
 
     @pytest.mark.credentials
-    def test_that_a_screenshot_cannot_be_added_via_an_invalid_file_format(self, mozwebqa, login, free_app):
+    def test_that_a_screenshot_cannot_be_added_via_an_invalid_file_format(self, mozwebqa, login_existing, free_app):
         """Check that a tiff cannot be successfully uploaded as a screenshot."""
 
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
@@ -159,7 +159,7 @@ class TestDeveloperHub(BaseTest):
         Assert.contains('Images must be either PNG or JPG.', screenshot_upload_error_message)
 
     @pytest.mark.credentials
-    def test_that_an_icon_cannot_be_added_via_an_invalid_file_format(self, mozwebqa, login, free_app):
+    def test_that_an_icon_cannot_be_added_via_an_invalid_file_format(self, mozwebqa, login_existing, free_app):
         """Check that a tiff cannot be successfully uploaded as an app icon."""
 
         edit_listing = self._go_to_edit_listing_page(mozwebqa, free_app)
@@ -175,7 +175,7 @@ class TestDeveloperHub(BaseTest):
 
     @pytest.mark.nondestructive
     @pytest.mark.credentials
-    def test_that_checks_apps_are_sorted_by_name(self, mozwebqa, login):
+    def test_that_checks_apps_are_sorted_by_name(self, mozwebqa, login_existing):
         dev_home = Home(mozwebqa)
         dev_submissions = dev_home.header.click_my_submissions()
         dev_submissions.sorter.sort_by('Name')
@@ -185,7 +185,7 @@ class TestDeveloperHub(BaseTest):
 
     @pytest.mark.nondestructive
     @pytest.mark.credentials
-    def test_that_checks_apps_are_sorted_by_date(self, mozwebqa, login):
+    def test_that_checks_apps_are_sorted_by_date(self, mozwebqa, login_existing):
         dev_home = Home(mozwebqa)
         dev_submissions = dev_home.header.click_my_submissions()
         dev_submissions.sorter.sort_by('Created')

--- a/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
+++ b/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
@@ -16,7 +16,7 @@ from tests.base_test import BaseTest
 class TestDeveloperHubSubmitApps(BaseTest):
 
     @pytest.mark.credentials
-    def test_packaged_app_submission(self, mozwebqa, login):
+    def test_packaged_app_submission(self, mozwebqa, login_new):
         if '-dev.allizom' in mozwebqa.base_url:
             env = 'dev'
         else:
@@ -86,7 +86,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
             delete_popup.delete_app()
 
     @pytest.mark.credentials
-    def test_hosted_paid_app_submission(self, mozwebqa, login):
+    def test_hosted_paid_app_submission(self, mozwebqa, login_new):
         if '-dev.allizom' in mozwebqa.base_url:
             env = 'dev'
         else:
@@ -149,6 +149,9 @@ class TestDeveloperHubSubmitApps(BaseTest):
             # setup payments
             payments = content_ratings.click_setup_payments()
 
+            # add a payment account
+            payments.add_payment_account()
+
             # select payment account
             payments.select_payment_account()
 
@@ -169,7 +172,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
             delete_popup.delete_app()
 
     @pytest.mark.credentials
-    def test_hosted_app_submission(self, mozwebqa, login):
+    def test_hosted_app_submission(self, mozwebqa, login_new):
         if '-dev.allizom' in mozwebqa.base_url:
             env = 'dev'
         else:
@@ -235,7 +238,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
             delete_popup.delete_app()
 
     @pytest.mark.credentials
-    def test_check_submission_of_an_app_with_XSS_in_its_app_name(self, mozwebqa, login):
+    def test_check_submission_of_an_app_with_XSS_in_its_app_name(self, mozwebqa, login_new):
         if '-dev.allizom' in mozwebqa.base_url:
             env = 'dev'
         else:
@@ -312,7 +315,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
             delete_popup.delete_app()
 
     @pytest.mark.credentials
-    def test_new_version_submission_for_awaiting_review_app(self, mozwebqa, login):
+    def test_new_version_submission_for_awaiting_review_app(self, mozwebqa, login_new):
         if '-dev.allizom' in mozwebqa.base_url:
             env = 'dev'
         else:


### PR DESCRIPTION
This will check for the presence of a payment account and create one if none exist. I did test this locally and it worked, but I am now unable to delete the payment account that I created, so I cannot test the logic that checks for no payment accounts again. Any reviewers will have the same issue.

@krupa Are you able to delete the payment account that was created when I ran my version of this, so reviewers can test it? I think that would need to be coordinated because after this code creates another payment account we would need intervention again to delete it to test again.

@rbillings | @m8ttyB | @davehunt r? please and thank you