### PR TITLE
Update test suite to work with FxAPom v1.3.1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@
 
 from urlparse import urlparse
 
-from fxapom.fxapom import FxATestAccount
+from fxapom.fxapom import DEV_URL, FxATestAccount, PROD_URL
 import pytest
 
 from mocks.marketplace_api import MarketplaceAPI
@@ -13,7 +13,11 @@ from mocks.mock_application import MockApplication
 
 @pytest.fixture
 def fxa_test_account(mozwebqa):
-    return FxATestAccount(mozwebqa.base_url).create_account()
+    api_url = DEV_URL
+    if ('-dev' not in mozwebqa.base_url and
+            'localhost' not in mozwebqa.base_url):
+        api_url = PROD_URL
+    return FxATestAccount(api_url).create_account()
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -13,10 +13,8 @@ from mocks.mock_application import MockApplication
 
 @pytest.fixture
 def fxa_test_account(mozwebqa):
-    api_url = DEV_URL
-    if ('-dev' not in mozwebqa.base_url and
-            'localhost' not in mozwebqa.base_url):
-        api_url = PROD_URL
+    prod_hosts = ['marketplace.mozilla.org', 'marketplace.allizom.org']
+    api_url = PROD_URL if urlparse(mozwebqa.base_url).hostname in prod_hosts else DEV_URL
     return FxATestAccount(api_url).create_account()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ chardet==2.1.1
 execnet==1.1
 requests==2.4.3
 Marketplace==0.9.1
-fxapom==1.2
+fxapom==1.3.1


### PR DESCRIPTION
This is required to be able to run against Fireplace on Travis

Adhoc running against dev at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/6/

@davehunt r?