### PR TITLE
Remove check for search placeholder text as the search form is not expanded

### DIFF
--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -34,7 +34,6 @@ class TestConsumerPage(BaseTest):
 
         Assert.true(home_page.header.is_logo_visible)
         Assert.true(home_page.header.is_search_visible)
-        Assert.equal(home_page.header.search_field_placeholder, u'Search Marketplace\u2026')
         Assert.true(home_page.header.is_sign_in_visible)
 
     @pytest.mark.sanity


### PR DESCRIPTION
This assertion was failing on `marketplace.dev` [1] and I checked with @krupa and she agreed that we should not be checking this value without expanding the search form. Removing the check eliminates the failure.

Adhoc running at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/8/

[1] https://webqa-ci.mozilla.com/view/Buildmaster/job/marketplace.dev/227/HTML_Report/