### PR TITLE
Fix path error in _get_resource_path

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -15,7 +15,7 @@ class BaseTest:
     def _get_resource_path(self, filename):
         """Return the path to the resources folder in the current repo."""
         import os
-        path_to_resources_folder = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'resources')
+        path_to_resources_folder = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'resources')
         return os.path.join(path_to_resources_folder, filename)
 
     def _open_payment_settings_page(self, current_page):

--- a/tests/desktop/developer_hub/test_developer_hub.py
+++ b/tests/desktop/developer_hub/test_developer_hub.py
@@ -114,7 +114,6 @@ class TestDeveloperHub(BaseTest):
         compatibility_page.click_save_changes()
         Assert.contains('Please select a device.', compatibility_page.device_types_error_message)
 
-    @pytest.mark.xfail(reason='Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method')
     @pytest.mark.credentials
     def test_that_a_screenshot_can_be_added(self, mozwebqa, login, free_app):
         """Test the happy path for adding a screenshot for a free submitted app."""
@@ -142,7 +141,6 @@ class TestDeveloperHub(BaseTest):
         Assert.equal(before_screenshots_count + 1, len(edit_listing.screenshots_previews),
                      'Expected %s screenshots, but there are %s.' % (before_screenshots_count + 1, after_screenshots_count))
 
-    @pytest.mark.xfail(reason='Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method')
     @pytest.mark.credentials
     def test_that_a_screenshot_cannot_be_added_via_an_invalid_file_format(self, mozwebqa, login, free_app):
         """Check that a tiff cannot be successfully uploaded as a screenshot."""
@@ -160,7 +158,6 @@ class TestDeveloperHub(BaseTest):
         Assert.contains('There was an error uploading your file.', screenshot_upload_error_message)
         Assert.contains('Images must be either PNG or JPG.', screenshot_upload_error_message)
 
-    @pytest.mark.xfail(reason='Issue 618 - Test adding a screenshot on Dev_hub fails because send_keys() method')
     @pytest.mark.credentials
     def test_that_an_icon_cannot_be_added_via_an_invalid_file_format(self, mozwebqa, login, free_app):
         """Check that a tiff cannot be successfully uploaded as an app icon."""


### PR DESCRIPTION
Unxfail 3 tests that are now passing

Addresses issue #618 

Adhoc running at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/9/

@davehunt r?