### PR TITLE
Un-xfail test_searching_with_no_matching_results as bug 1177718 has been fixed

### DIFF
--- a/tests/mobile/test_search.py
+++ b/tests/mobile/test_search.py
@@ -41,7 +41,6 @@ class TestSearch():
 
         Assert.fail('The search results did not include the app: %s' % search_term)
 
-    @pytest.mark.xfail(reason='Bug 1177718 - Websites search is not working as expected')
     @pytest.mark.nondestructive
     def test_searching_with_no_matching_results(self, mozwebqa):
         search_term_with_no_result = 'abcdefghij'


### PR DESCRIPTION
Adhoc passed at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.mobile.adhoc/16/ 

@m8ttyB | @rbillings | @krupa r?