### PR TITLE
Update marketplace-tests to use FxAPom 1.4

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,7 @@ from mocks.mock_application import MockApplication
 def fxa_test_account(mozwebqa):
     prod_hosts = ['marketplace.firefox.com', 'marketplace.allizom.org']
     api_url = PROD_URL if urlparse(mozwebqa.base_url).hostname in prod_hosts else DEV_URL
-    return FxATestAccount(api_url).create_account()
+    return FxATestAccount(api_url)
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ chardet==2.1.1
 execnet==1.1
 requests==2.4.3
 Marketplace==0.9.1
-fxapom==1.3.1
+fxapom==1.4


### PR DESCRIPTION
@davehunt The only change we need in this repo is just the one line! I've tested it locally and it seems fine. 

We need to hold off merging this until fxapom==1.4 has been released, but I plan on doing that soon. Can you give this a quick r? first, please?