### PR TITLE
Improve test_recommended_tab_shows_up_only_if_checkbox_is_selected and add waits to address Travis failure

### DIFF
--- a/pages/desktop/consumer_pages/account_settings.py
+++ b/pages/desktop/consumer_pages/account_settings.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.select import Select
 
@@ -80,7 +81,9 @@ class BasicInfo(AccountSettings):
 
     def save_changes(self):
         self.selenium.find_element(*self._save_button_locator).click()
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_visible(*self._notification_locator))
+        notification = self.selenium.find_element(*self._notification_locator)
+        WebDriverWait(self.selenium, self.timeout).until(
+            EC.visibility_of(notification))
 
     def edit_display_name(self, text):
         self.type_in_element(self._display_name_input_locator, text)
@@ -114,8 +117,14 @@ class BasicInfo(AccountSettings):
         select = Select(element)
         select.select_by_value(option_value)
 
-    def toggle_recommendations(self):
-        self.selenium.find_element(*self._recommendations_checkbox_locator).click()
+    def disable_recommendations(self):
+        checkbox = self.selenium.find_element(*self._recommendations_checkbox_locator)
+        assert checkbox.is_selected(), 'Recommendations checkbox is expected to be checked, but it is unchecked'
+        checkbox.click()
+
+    def wait_for_recommended_tab_not_visible(self):
+        WebDriverWait(self.selenium, self.timeout).until(
+            EC.invisibility_of_element_located(self._recommended_tab_locator))
 
     @property
     def is_recommended_tab_visible(self):

--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -105,7 +105,8 @@ class TestAccounts(BaseTest):
 
         Assert.true(basic_info.is_recommended_tab_visible)
 
-        basic_info.toggle_recommendations()
+        basic_info.disable_recommendations()
         basic_info.save_changes()
+        basic_info.wait_for_recommended_tab_not_visible()
 
         Assert.false(basic_info.is_recommended_tab_visible)


### PR DESCRIPTION
This test seems to be failing consistently on Travis (i.e., it fails both on the main Fireplace repo and on my fork). A report, showing the failure can be seen at [1]. It looks like perhaps we aren't waiting long enough for the condition we expect, so I added a wait, and also made another improvement.

A run against my fork [2] that picks up this change from this branch yielded a pass, so I think this is worthwhile putting in.

@davehunt r?

[1] https://fireplace-tests.s3.amazonaws.com/bobsilverberg/fireplace/32/32.3/index.html
[2] https://travis-ci.org/bobsilverberg/fireplace/jobs/72304998