### PR TITLE
Improve the search wait to check for classes

### DIFF
--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -66,7 +66,6 @@ class Base(Page):
 
     class HeaderRegion(Page):
 
-        _site_header_locator = (By.ID, 'mkt-nav--site-header')
         _search_toggle_locator = (By.CSS_SELECTOR, '.header--search-toggle')
         _search_input_locator = (By.ID, 'search-q')
         _search_input_placeholder_locator = (By.CSS_SELECTOR, '.header-child--input-placeholder')
@@ -119,14 +118,12 @@ class Base(Page):
             :Args:
              - search_term - string value of the search field
             """
-            site_header = self.selenium.find_element(*self._site_header_locator)
             search_toggle = self.selenium.find_element(*self._search_toggle_locator)
+            search_field = self.selenium.find_element(*self._search_input_locator)
             WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of(search_toggle))
             search_toggle.click()
             WebDriverWait(self.selenium, self.timeout).until(
-                lambda s: 'mkt-header--showing-child' in site_header.get_attribute('class'))
-            search_field = self.selenium.find_element(*self._search_input_locator)
-            WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of(search_field))
+                lambda s: search_field.location['y'] > 100)
             search_field.send_keys(search_term)
             search_field.submit()
             from pages.desktop.consumer_pages.search import Search

--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -66,6 +66,7 @@ class Base(Page):
 
     class HeaderRegion(Page):
 
+        _site_header_locator = (By.ID, 'mkt-nav--site-header')
         _search_toggle_locator = (By.CSS_SELECTOR, '.header--search-toggle')
         _search_input_locator = (By.ID, 'search-q')
         _search_input_placeholder_locator = (By.CSS_SELECTOR, '.header-child--input-placeholder')
@@ -118,9 +119,12 @@ class Base(Page):
             :Args:
              - search_term - string value of the search field
             """
+            site_header = self.selenium.find_element(*self._site_header_locator)
             search_toggle = self.selenium.find_element(*self._search_toggle_locator)
             WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of(search_toggle))
             search_toggle.click()
+            WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: 'mkt-header--showing-child' in site_header.get_attribute('class'))
             search_field = self.selenium.find_element(*self._search_input_locator)
             WebDriverWait(self.selenium, self.timeout).until(EC.visibility_of(search_field))
             search_field.send_keys(search_term)


### PR DESCRIPTION
The waiting for an element to be displayed that I added didn't seem to solve the problem entirely, as can be seen at [1]. I added a new wait which checks for a class that is added to an element when the search input is displayed, and that seems to have improved things [2].

@davehunt r?

[1] https://fireplace-tests.s3.amazonaws.com/bobsilverberg/fireplace/37/37.3/index.html
[2] https://fireplace-tests.s3.amazonaws.com/bobsilverberg/fireplace/39/39.3/index.html