### PR TITLE
Test fixes neccesary due to recent changes on the home and games pages

### DIFF
--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -24,8 +24,6 @@ class Home(Base):
     _new_tab_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[href*=new]')
     _popular_tab_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[href*=popular]')
     _feed_title_locator = (By.CSS_SELECTOR, '.subheader > h1')
-    _promo_box_locator = (By.CSS_SELECTOR, '.desktop-promo')
-    _promo_box_items_locator = (By.CSS_SELECTOR, '.desktop-promo-item')
 
     def go_to_homepage(self):
         self.set_window_size()
@@ -33,14 +31,6 @@ class Home(Base):
         WebDriverWait(self.selenium, self.timeout).until(
             lambda s: self.selenium.execute_script('return jQuery.isReady == true'))
         self.wait_for_element_visible(*self._site_navigation_menu_locator)
-
-    @property
-    def is_promo_box_visible(self):
-        return self.is_element_visible(*self._promo_box_locator)
-
-    @property
-    def promo_box_items_number(self):
-        return len(self.find_elements(*self._promo_box_items_locator))
 
     @property
     def category_menu_text(self):

--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -47,7 +47,7 @@ class TestConsumerPage(BaseTest):
 
         categories = home_page.categories.items
         # only check the first three categories
-        for c in range(3):
+        for c in range(1, 4):
             home_page.open_categories_menu()
             category = categories[c]
             category_name = category.name

--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -14,15 +12,6 @@ from pages.desktop.consumer_pages.home import Home
 
 
 class TestConsumerPage(BaseTest):
-
-    @pytest.mark.nondestructive
-    def test_that_promo_module_is_visible(self, mozwebqa):
-
-        home_page = Home(mozwebqa)
-        home_page.go_to_homepage()
-
-        Assert.true(home_page.is_promo_box_visible)
-        Assert.greater(home_page.promo_box_items_number, 0)
 
     @pytest.mark.sanity
     @pytest.mark.action_chains


### PR DESCRIPTION
This removed the promo box test because it's been replaced with the games promotion on the home page, and avoids the games category page when testing categories due to that now being a special case. This will fix the outstanding failures on dev and staging, but will fail against production until these changes are deployed there.

Pinging @krupa for review. Adhoc run here: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/30/