### PR TITLE
Fix failing tests on marketplace.dev

### DIFF
--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -60,7 +60,7 @@ class TestConsumerPage(BaseTest):
             Assert.true(category_page.popular_tab_class == 'active')
 
             # only check the first three apps in the category
-            for a in range(3):
+            for a in range(min(len(apps), 3)):
                 app = apps[a]
                 Assert.true(app.is_name_visible)
                 Assert.true(app.is_icon_visible)


### PR DESCRIPTION
This addresses the 3 failures as seen at https://webqa-ci.mozilla.com/view/Buildmaster/job/marketplace.dev.sanity.saucelabs/891/

Adhoc running at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/41/

Changes:
Remove a footer link that is no longer there - note that I'm still waiting to hear from @krupa about whether this change to the test is ok
Make sure that we do not try to loop through more apps per category than exist

Note that `test_opening_category_pages_from_categories_menu` might still fail as it's waiting for the stability improvement from https://github.com/mozilla/marketplace-tests/pull/711 which we should try to merge asap

@davehunt r?