### PR TITLE
Add utf-8 encoding back

### DIFF
--- a/pages/desktop/developer_hub/edit_app.py
+++ b/pages/desktop/developer_hub/edit_app.py
@@ -1,7 +1,8 @@
+# -*- coding: utf-8 -*-
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait

--- a/pages/desktop/developer_hub/manage_status.py
+++ b/pages/desktop/developer_hub/manage_status.py
@@ -1,4 +1,6 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
+# -*- coding: utf-8 -*-
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 


### PR DESCRIPTION
This seems to fix the failures we were seeing at https://webqa-ci.mozilla.com/job/marketplace.dev.developer_hub/lastCompletedBuild/HTML_Report/

Adhoc at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/43/