### PR TITLE
Fix issues in expected element moving

### DIFF
--- a/expected.py
+++ b/expected.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import time
+
 
 class element_moving(object):
     """An expectation for checking that an element is moving.
@@ -19,11 +21,17 @@ class element_moving(object):
         self.history = []
 
     def __call__(self, selenium):
+        self.collect()  # collect initial element state
         while len(self.history) < self.precision:
-            self.history.append((
-                str(self.element.location),
-                str(self.element.size)))
+            # ensure we have enough states in history to match the precision
+            time.sleep(0.1)  # give the element a chance to change state
+            self.collect()
         return len(set(self.history[-self.precision:])) == 1
+
+    def collect(self):
+        self.history.append((
+            str(self.element.location),
+            str(self.element.size)))
 
 
 class element_not_moving(element_moving):


### PR DESCRIPTION
Hey @bobsilverberg this should fix our two issues. The first was as we discussed - the history could never exceed the precision. The second was due to the initial population of history happening too fast - before the element had a chance to start moving. I added a 0.1 second delay between the collection of the initial states.