### PR TITLE
Xfail test_that_user_can_purchase_an_app due to Bug 1212152 - App purchases are failing on dev

### DIFF
--- a/tests/desktop/consumer_pages/test_purchase_app.py
+++ b/tests/desktop/consumer_pages/test_purchase_app.py
@@ -18,6 +18,8 @@ class TestPurchaseApp(BaseTest):
     def test_that_user_can_purchase_an_app(self, mozwebqa, new_user):
         if '-dev' not in mozwebqa.base_url:
             pytest.skip("Payments can only be tested on dev.")
+        else:
+            pytest.xfail("Bug 1212152 - App purchases are failing on dev")
 
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()


### PR DESCRIPTION
This test has been failing intermittently for a long time [1] and a bug [2] has now been opened for it. It sounds like we might want to xfail the test until the bug is addressed as it is making a lot of our runs fail, which can mask other issues that may come up.

@davehunt | @krupa r?

[1] https://webqa-ci.mozilla.com/view/Buildmaster/job/marketplace.dev/lastCompletedBuild/testReport/test_purchase_app/TestPurchaseApp/test_that_user_can_purchase_an_app/history/
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1212152