### PR TITLE
Changes to locators for Marketplace nav changes

### DIFF
--- a/pages/desktop/consumer_pages/account_settings.py
+++ b/pages/desktop/consumer_pages/account_settings.py
@@ -44,7 +44,7 @@ class BasicInfo(AccountSettings):
     https://marketplace-dev.allizom.org/en-US/settings/
     """
 
-    _page_title = 'Account Settings | Firefox Marketplace'
+    _page_title = 'Settings | Firefox Marketplace'
 
     _email_locator = (By.CSS_SELECTOR, '.settings-email.account-field > p')
     _display_name_input_locator = (By.ID, 'display_name')
@@ -57,7 +57,7 @@ class BasicInfo(AccountSettings):
     _region_field_locator = (By.CSS_SELECTOR, '.region span')
     _region_locator = (By.CSS_SELECTOR, '#account-settings .region')
     _recommendations_checkbox_locator = (By.CSS_SELECTOR, '#enable_recommendations')
-    _recommended_tab_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[title="Recommended"]')
+    _recommended_tab_locator = (By.CSS_SELECTOR, '#navigation li a.recommended')
 
     @property
     def email(self):

--- a/pages/desktop/consumer_pages/base.py
+++ b/pages/desktop/consumer_pages/base.py
@@ -65,22 +65,22 @@ class Base(Page):
 
     class HeaderRegion(Page):
 
-        _categories_header_locator = (By.ID, 'header--categories')
-        _categories_toggle_locator = (By.CLASS_NAME, 'header--categories-toggle')
-        _categories_locator = (By.CSS_SELECTOR, '#header--categories mkt-category-item')
-        _search_toggle_locator = (By.CSS_SELECTOR, '.header--search-toggle')
-        _search_input_locator = (By.ID, 'search-q')
+        _categories_header_locator = (By.CLASS_NAME, 'app-categories')
+        _categories_toggle_locator = (By.CLASS_NAME, 'nav-category-link')
+        _categories_locator = (By.CSS_SELECTOR, '.app-categories li:not(.cat-menu-all)')
+        _search_toggle_locator = (By.CLASS_NAME, 'search-btn-desktop')
+        _search_input_locator = (By.ID, 'search-q-desktop')
         _search_input_placeholder_locator = (By.CSS_SELECTOR, '.header-child--input-placeholder')
         _suggestion_list_title_locator = (By.CSS_SELECTOR, '#site-search-suggestions .wrap > p > a > span')
         _search_suggestions_locator = (By.CSS_SELECTOR, '#site-search-suggestions')
         _search_suggestions_list_locator = (By.CSS_SELECTOR, '#site-search-suggestions > ul > li')
-        _site_logo_locator = (By.CSS_SELECTOR, '.site > a')
-        _settings_toggle_locator = (By.CSS_SELECTOR, '.header--settings-toggle')
-        _settings_menu_locator = (By.ID, 'header--settings')
-        _settings_menu_item_locator = (By.CSS_SELECTOR, '.mkt-header-child--link[href*="settings"]')
-        _my_apps_menu_locator = (By.CSS_SELECTOR, '.mkt-header-child--link[href*="purchases"]')
-        _sign_out_locator = (By.CSS_SELECTOR, '.logout')
-        _sign_in_locator = (By.CSS_SELECTOR, '.mkt-header--actions-link.persona:not(.register)')
+        _site_logo_locator = (By.CSS_SELECTOR, '#navigation .site > a')
+        _settings_toggle_locator = (By.CLASS_NAME, 'mkt-settings-btn')
+        _settings_menu_locator = (By.CLASS_NAME, 'settings-menu-desktop')
+        _settings_menu_item_locator = (By.CSS_SELECTOR, '.settings-menu-desktop a[href*="settings"]')
+        _my_apps_menu_locator = (By.CSS_SELECTOR, '.settings-menu-desktop a[href*="purchases"]')
+        _sign_out_locator = (By.CLASS_NAME, 'logout')
+        _sign_in_locator = (By.CSS_SELECTOR, '.nav--settings--logged-out.persona:not(.register)')
 
         @property
         def is_user_logged_in(self):
@@ -102,9 +102,9 @@ class Base(Page):
 
         def open_settings_menu(self):
             settings_menu = self.selenium.find_element(*self._settings_menu_locator)
-            if not settings_menu.is_displayed():
+            if 'active' not in settings_menu.get_attribute('class'):
                 self.selenium.find_element(*self._settings_toggle_locator).click()
-                WebDriverWait(self.selenium, self.timeout).until(lambda s: settings_menu.is_displayed())
+                WebDriverWait(self.selenium, self.timeout).until(expected.element_not_moving(settings_menu))
 
         def click_sign_in(self):
             self.wait_for_element_visible(*self._sign_in_locator)
@@ -209,7 +209,7 @@ class Base(Page):
 
         class Category(PageRegion):
 
-            _link_locator = (By.CLASS_NAME, 'mkt-category-link')
+            _link_locator = (By.TAG_NAME, 'a')
 
             @property
             def name(self):

--- a/pages/desktop/consumer_pages/category.py
+++ b/pages/desktop/consumer_pages/category.py
@@ -16,8 +16,9 @@ class Category(Base):
 
     _page_title = 'Firefox Marketplace'
 
-    _popular_tab_locator = (By.CSS_SELECTOR, '.app-list-filters-sort a:nth-child(1)')
-    _new_popular_tabs_locator = (By.CSS_SELECTOR, '.app-list-filters-sort')
+    _new_popular_data_page_type_container_locator = (By.TAG_NAME, 'body')
+    _popular_tab_locator = (By.CLASS_NAME, 'sort-toggle-popular')
+    _new_popular_tabs_locator = (By.CLASS_NAME, 'sort-toggle')
     _category_section_title_locator = (By.CSS_SELECTOR, '.subheader > h1')
     _category_apps_locator = (By.CSS_SELECTOR, '.item.result.app-list-app')
 
@@ -34,8 +35,9 @@ class Category(Base):
         return self.selenium.find_element(*self._category_section_title_locator).text
 
     @property
-    def popular_tab_class(self):
-        return self.selenium.find_element(*self._popular_tab_locator).get_attribute('class')
+    def is_popular_tab_selected(self):
+        return 'popular' in self.selenium.find_element(
+            *self._new_popular_data_page_type_container_locator).get_attribute('data-page-type')
 
     @property
     def is_new_popular_tabs_visible(self):

--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -14,8 +14,8 @@ class Home(Base):
     _site_navigation_menu_locator = (By.CSS_SELECTOR, 'mkt-header-nav')
     _item_locator = (By.CSS_SELECTOR, '.app-list-app')
     _first_app_name_locator = (By.CSS_SELECTOR, '.app-list .mkt-product-name')
-    _new_tab_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[href*=new]')
-    _popular_tab_menu_locator = (By.CSS_SELECTOR, '.mkt-header-nav--link[href*=popular]')
+    _new_tab_menu_locator = (By.CSS_SELECTOR, '#navigation li a.new')
+    _popular_tab_menu_locator = (By.CSS_SELECTOR, '#navigation li a.popular')
     _feed_title_locator = (By.CSS_SELECTOR, '.subheader > h1')
 
     def go_to_homepage(self):

--- a/pages/desktop/consumer_pages/search.py
+++ b/pages/desktop/consumer_pages/search.py
@@ -17,7 +17,7 @@ class Search(Base, Sorter, Filter):
     https://marketplace-dev.allizom.org/
     """
 
-    _expand_button_locator = (By.CSS_SELECTOR, '#search-results .app-list-filters-expand-toggle')
+    _expand_button_locator = (By.CSS_SELECTOR, '.search-results-header-desktop .app-list-filters-expand-toggle')
     _results_locator = (By.CSS_SELECTOR, '#search-results .item.result.app-list-app')
     _applied_filters_locator = (By.CSS_SELECTOR, '.applied-filters > ol > li > a')
     _search_results_section_title_locator = (By.CSS_SELECTOR, '.search-results-header-desktop')

--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -49,7 +49,7 @@ class TestConsumerPage(BaseTest):
             apps = category_page.apps
             assert len(apps) > 0
             assert category_page.is_new_popular_tabs_visible
-            assert 'active' == category_page.popular_tab_class
+            assert category_page.is_popular_tab_selected
 
             # only check the first three apps in the category
             for app in apps[:3]:
@@ -64,12 +64,12 @@ class TestConsumerPage(BaseTest):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
         home_page.click_new_tab()
-        assert 'New' == home_page.feed_title_text
+        assert 'New' in home_page.feed_title_text
         assert home_page.apps_are_visible
         assert home_page.elements_count > 0
 
         home_page.click_popular_tab()
-        assert 'Popular' == home_page.feed_title_text
+        assert 'Popular' in home_page.feed_title_text
         assert home_page.apps_are_visible
         assert home_page.elements_count > 0
 

--- a/tests/desktop/consumer_pages/test_search.py
+++ b/tests/desktop/consumer_pages/test_search.py
@@ -74,10 +74,11 @@ class TestSearching(BaseTest):
         search_term = self._take_first_free_app_name(mozwebqa)
         search_page = home_page.header.search(search_term)
         search_page.click_expand_button()
+        results = search_page.results
 
         # check the first 5 results
-        for i in range(min(len(search_page.results), 5)):
-            assert search_page.results[i].is_install_button_visible
-            assert search_page.results[i].is_icon_visible
-            assert search_page.results[i].is_rating_visible
-            assert search_page.results[i].are_screenshots_visible
+        for i in range(min(len(results), 5)):
+            assert results[i].is_install_button_visible
+            assert results[i].is_icon_visible
+            assert results[i].is_rating_visible
+            assert results[i].are_screenshots_visible


### PR DESCRIPTION
Fixes #725 

These changes restore coverage for desktop consumer pages tests. There is still one failure, `test_recommended_tab_shows_up_only_if_checkbox_is_selected` which I believe to be a bug. I tried asking about it in #marketplace, but had no luck, so I'm waiting to talk to @krupa about it.

Even with that test failing I think it's worth merging this to restore most of the coverage.

Adhoc currently running at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/60/

Requesting review from @mozilla/web-qa-sorcerers 