### PR TITLE
Remove My Apps steps from test_settings_dropdown_menu which restores coverage

### DIFF
--- a/tests/desktop/consumer_pages/test_home_page.py
+++ b/tests/desktop/consumer_pages/test_home_page.py
@@ -73,7 +73,6 @@ class TestConsumerPage(BaseTest):
         assert home_page.apps_are_visible
         assert home_page.elements_count > 0
 
-    @pytest.mark.xfail(reason='Issue 657 - Need an app installed to test My Apps')
     @pytest.mark.sanity
     @pytest.mark.nondestructive
     def test_settings_dropdown_menu(self, mozwebqa, new_user):
@@ -90,14 +89,6 @@ class TestConsumerPage(BaseTest):
         assert user_settings.is_region_field_visible
         assert user_settings.is_save_button_visible
         assert user_settings.is_sign_out_button_visible
-
-        # Verify My Apps menu
-        home_page.go_to_homepage()
-        my_apps_page = home_page.header.click_my_apps()
-        assert my_apps_page.is_the_current_page
-        my_apps_page.click_expand_button()
-        for i in range(len(my_apps_page.apps)):
-            assert my_apps_page.apps[i].are_screenshots_visible
 
     @pytest.mark.sanity
     @pytest.mark.credentials


### PR DESCRIPTION
As per a conversation with @krupa, we cannot install an app on desktop, so we cannot really test the My Apps page anyway. This test, which has been xfailed for a long time, doesn't really need that step anyway, as it's a test for the settings page.

This change restores coverage for the settings page by allowing this test to pass again.

Adhoc at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.adhoc/62/

Note that `test_opening_category_pages_from_categories_menu` and `test_recommended_tab_shows_up_only_if_checkbox_is_selected` are both expected to fail due to known bugs which are being worked on.

@mozilla/web-qa-sorcerers r?