### PR TITLE
Xfail test_recommended_tab_shows_up_only_if_checkbox_is_selected due to Bug 1102883 - Recommendations checkbox does not work correctly

### DIFF
--- a/tests/desktop/consumer_pages/test_users_account.py
+++ b/tests/desktop/consumer_pages/test_users_account.py
@@ -76,6 +76,7 @@ class TestAccounts(BaseTest):
         profile_page.refresh_page()
         assert name == profile_page.display_name
 
+    @pytest.mark.xfail(reason='Bug 1102883 - Recommendations checkbox does not work correctly')
     @pytest.mark.nondestructive
     def test_recommended_tab_shows_up_only_if_checkbox_is_selected(self, mozwebqa, new_user):
         basic_info = BasicInfo(mozwebqa)


### PR DESCRIPTION
@krupa Suggested we xfail this test if the bug isn't fixed by today, and I suspect it may be some time before it is fixed. This should restore most of our suites to green.

@mozilla/web-qa-sorcerers r?