### PR TITLE
Update mobile tests to address nav changes

### DIFF
--- a/pages/mobile/base.py
+++ b/pages/mobile/base.py
@@ -5,6 +5,7 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
+import expected
 from pages.page import Page
 from pages.page import PageRegion
 
@@ -56,8 +57,8 @@ class Base(Page):
         return Header(self.testsetup)
 
     @property
-    def nav_menu(self):
-        return NavMenu(self.testsetup)
+    def more_menu(self):
+        return MoreMenu(self.testsetup)
 
     @property
     def popular_apps(self):
@@ -84,10 +85,10 @@ class Base(Page):
 
 class Header(Page):
 
-    _search_toggle_locator = (By.CSS_SELECTOR, '.header--search-toggle')
+    _search_toggle_locator = (By.CLASS_NAME, 'mkt-search-btn')
     _search_input_locator = (By.ID, 'search-q')
-    _back_button_locator = (By.CSS_SELECTOR, '.hamburger')
-    _marketplace_icon_locator = (By.CSS_SELECTOR, '.wordmark')
+    _back_button_locator = (By.CLASS_NAME, 'header-back-btn')
+    _marketplace_icon_locator = (By.CLASS_NAME, 'mkt-wordmark')
 
     def search(self, search_term):
         """
@@ -97,7 +98,7 @@ class Header(Page):
         """
         self.selenium.find_element(*self._search_toggle_locator).click()
         search_field = self.selenium.find_element(*self._search_input_locator)
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: search_field.is_displayed())
+        WebDriverWait(self.selenium, self.timeout).until(expected.element_not_moving(search_field))
         search_field.send_keys(search_term)
         search_field.submit()
         from pages.mobile.search import Search
@@ -127,21 +128,21 @@ class Header(Page):
         return self.is_element_visible(*self._back_button_locator)
 
 
-class NavMenu(Base):
+class MoreMenu(Base):
 
-    _nav_menu_toggle_locator = (By.CSS_SELECTOR, 'mkt-nav-toggle button')
-    _nav_menu_locator = (By.TAG_NAME, 'mkt-nav-root')
-    _settings_menu_item_locator = (By.CSS_SELECTOR, '.mkt-nav--link[href*="settings"]')
-    _sign_in_menu_item_locator = (By.CSS_SELECTOR, '.mkt-nav--link.persona:not(.register)')
+    _more_menu_toggle_locator = (By.CSS_SELECTOR, '#navigation a[data-nav-type="more"]')
+    _more_menu_locator = (By.CLASS_NAME, 'more-menu-overlay')
+    _settings_menu_item_locator = (By.CLASS_NAME, 'more-menu-settings')
+    _sign_in_menu_item_locator = (By.CLASS_NAME, 'more-menu-sign-in')
     _new_menu_item_locator = (By.CSS_SELECTOR, '.mkt-nav--link[href*="new"]')
     _popular_menu_item_locator = (By.CSS_SELECTOR, '.mkt-nav--link[href*="popular"]')
     _categories_menu_item_locator = (By.CSS_SELECTOR, '.mkt-nav--link[title="Categories"]')
 
     def open(self):
-        menu = self.selenium.find_element(*self._nav_menu_locator)
-        if not menu.is_displayed():
-            self.selenium.find_element(*self._nav_menu_toggle_locator).click()
-            WebDriverWait(self.selenium, self.timeout).until(lambda s: menu.is_displayed())
+        menu = self.selenium.find_element(*self._more_menu_locator)
+        if 'overlay-visible' not in menu.get_attribute('class'):
+            self.selenium.find_element(*self._more_menu_toggle_locator).click()
+            WebDriverWait(self.selenium, self.timeout).until(expected.element_not_moving(menu))
 
     def click_settings(self):
         self.open()

--- a/pages/mobile/home.py
+++ b/pages/mobile/home.py
@@ -11,17 +11,13 @@ class Home(Base):
 
     _page_title = "Firefox Marketplace"
 
-    _site_navigation_header_locator = (By.ID, 'mkt-nav--site-header')
+    _site_navigation_footer_locator = (By.ID, 'navigation')
     _promo_box_locator = (By.CSS_SELECTOR, '.desktop-promo')
 
     def go_to_homepage(self):
         self.selenium.get(self.base_url)
-        self.wait_for_element_present(*self._site_navigation_header_locator)
+        self.wait_for_element_present(*self._site_navigation_footer_locator)
 
     @property
     def is_promo_box_not_visible(self):
         return self.is_element_not_visible(*self._promo_box_locator)
-
-    @property
-    def is_nav_header_visible(self):
-        return self.is_element_visible(*self._site_navigation_header_locator)

--- a/tests/mobile/test_home_page.py
+++ b/tests/mobile/test_home_page.py
@@ -19,17 +19,17 @@ class TestHomepage():
     def test_that_verifies_categories_menu(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        categories = home_page.nav_menu.click_categories()
+        categories = home_page.more_menu.click_categories()
         assert len(categories.categories) > 0
 
     @pytest.mark.nondestructive
     def test_switch_between_new_and_popular_pages(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        popular_apps = home_page.nav_menu.click_popular()
+        popular_apps = home_page.more_menu.click_popular()
         assert 'Popular' == home_page.feed_title_text
         assert len(popular_apps) > 0
 
-        new_apps = home_page.nav_menu.click_new()
+        new_apps = home_page.more_menu.click_new()
         assert 'New' == home_page.feed_title_text
         assert len(new_apps) > 0

--- a/tests/mobile/test_reviews.py
+++ b/tests/mobile/test_reviews.py
@@ -62,7 +62,7 @@ class TestReviews(BaseTest):
         mock_review = MockReview()
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        home_page.nav_menu.click_sign_in()
+        home_page.more_menu.click_sign_in()
         home_page.login(new_user['email'], new_user['password'])
         details_page = home_page.go_to_first_free_app_page()
         assert details_page.is_product_details_visible

--- a/tests/mobile/test_users_account.py
+++ b/tests/mobile/test_users_account.py
@@ -16,9 +16,9 @@ class TestAccounts(BaseTest):
     def test_user_can_login_and_logout(self, mozwebqa, new_user):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        home_page.nav_menu.click_sign_in()
+        home_page.more_menu.click_sign_in()
         home_page.login(new_user['email'], new_user['password'])
-        settings_page = home_page.nav_menu.click_settings()
+        settings_page = home_page.more_menu.click_settings()
         assert new_user['email'] == settings_page.email_text
 
         settings_page.click_sign_out()
@@ -31,9 +31,9 @@ class TestAccounts(BaseTest):
         """
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        home_page.nav_menu.click_sign_in()
+        home_page.more_menu.click_sign_in()
         home_page.login(new_user['email'], new_user['password'])
-        settings_page = home_page.nav_menu.click_settings()
+        settings_page = home_page.more_menu.click_settings()
         assert new_user['email'] == settings_page.email_text
 
         home_page = settings_page.header.click_marketplace_icon()


### PR DESCRIPTION
This restores coverage for the mobile tests. There are two tests currently expected to fail due to known bugs. I don't have the bug numbers handy, but will try to get them from @krupa and then xfail the tests.

The tests that will fail are `test_switch_between_new_and_popular_pages` and `test_that_verifies_categories_menu`.

Adhoc at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.mobile.adhoc/29/

@mozilla/web-qa-sorcerers r?