### PR TITLE
More fixes for mobile tests

### DIFF
--- a/pages/mobile/add_review.py
+++ b/pages/mobile/add_review.py
@@ -29,5 +29,7 @@ class AddReview(Base):
         self.wait_for_element_visible(*self._submit_review_button_locator)
         self.set_review_rating(rating)
         self.enter_review_with_text(body)
-        self.selenium.find_element(*self._submit_review_button_locator).click()
+        review_button = self.selenium.find_element(*self._submit_review_button_locator)
+        self.scroll_to_element(review_button)
+        review_button.click()
         self.wait_notification_box_visible()

--- a/pages/mobile/home.py
+++ b/pages/mobile/home.py
@@ -17,6 +17,7 @@ class Home(Base):
     def go_to_homepage(self):
         self.selenium.get(self.base_url)
         self.wait_for_element_present(*self._site_navigation_footer_locator)
+        self.close_banner()
 
     @property
     def is_promo_box_not_visible(self):

--- a/pages/mobile/item_list.py
+++ b/pages/mobile/item_list.py
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+import expected
+from pages.page import Page, PageRegion
+from pages.mobile.base import Base
+
+
+class ItemList(Base):
+
+    _item_locator = (By.CSS_SELECTOR, '.app-list .app-list-app')
+    _categories_button_locator = (By.CLASS_NAME, 'header-categories-btn')
+    _categories_menu_locator = (By.CLASS_NAME, 'cat-menu-overlay')
+    _new_button_locator = (By.CLASS_NAME, 'sort-toggle-new')
+    _popular_button_locator = (By.CLASS_NAME, 'sort-toggle-popular')
+    _new_popular_data_page_type_container_locator = (By.TAG_NAME, 'body')
+
+    @property
+    def is_new_selected(self):
+        return 'new' in self.selenium.find_element(
+            *self._new_popular_data_page_type_container_locator).get_attribute('data-page-type')
+
+    @property
+    def is_popular_selected(self):
+        return 'popular' in self.selenium.find_element(
+            *self._new_popular_data_page_type_container_locator).get_attribute('data-page-type')
+
+    def click_categories(self):
+        menu = self.selenium.find_element(*self._categories_menu_locator)
+        self.selenium.find_element(*self._categories_button_locator).click()
+        WebDriverWait(self.selenium, self.timeout).until(expected.element_not_moving(menu))
+        return self.Categories(self.testsetup)
+
+    def click_new(self):
+        self.selenium.find_element(*self._new_button_locator).click()
+
+    def click_popular(self):
+        self.selenium.find_element(*self._popular_button_locator).click()
+
+    def items(self, wait_for_items=True):
+        items = self.find_elements(*self._item_locator)
+        if wait_for_items:
+            WebDriverWait(self.selenium, self.timeout).until(lambda s: len(items) > 0)
+        return [self.Item(self.testsetup, item) for item in items]
+
+    class Categories(Page):
+
+        _category_item_locator = (By.CSS_SELECTOR, '.app-categories li:not(.cat-menu-all)')
+
+        def __init__(self, testsetup):
+            Page.__init__(self, testsetup)
+            # Wait for the first category to be visible
+            element = self.selenium.find_element(*self._category_item_locator)
+            WebDriverWait(self.selenium, self.timeout).until(lambda s: element.is_displayed())
+
+        @property
+        def categories(self):
+            return [self.CategoryItem(self.testsetup, web_element)
+                    for web_element in self.selenium.find_elements(*self._category_item_locator)]
+
+        class CategoryItem(PageRegion):
+
+            _category_link_locator = (By.CSS_SELECTOR, '.mkt-category-link')
+
+            @property
+            def name(self):
+                return self.find_element(*self._category_link_locator).text
+
+            @property
+            def link_to_category_page(self):
+                return self.find_element(*self._category_link_locator).get_attribute("href")
+
+            def click_category(self):
+                category_name = self.name
+                self.find_element(*self._category_link_locator).click()
+                from pages.desktop.consumer_pages.category import Category
+                return Category(self.testsetup, category_name)
+
+    class Item(PageRegion):
+
+        _name_locator = (By.CSS_SELECTOR, ".mkt-product-name")
+
+        @property
+        def name(self):
+            return self.find_element(*self._name_locator).text
+
+        def click(self):
+            self.selenium.find_element(*self._name_locator).click()
+            from pages.mobile.details import Details
+            return Details(self.testsetup)

--- a/pages/mobile/search.py
+++ b/pages/mobile/search.py
@@ -3,36 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 
-from pages.page import PageRegion
-from pages.mobile.base import Base
+from pages.mobile.item_list import ItemList
 
 
-class Search(Base):
+class Search(ItemList):
 
-    _result_locator = (By.CSS_SELECTOR, '#search-results .item.result')
     _no_results_locator = (By.CSS_SELECTOR, '.no-results')
 
     @property
     def no_results_text(self):
         return self.find_element(*self._no_results_locator).text
-
-    def results(self, wait_for_results=True):
-        results = self.find_elements(*self._result_locator)
-        if wait_for_results:
-            WebDriverWait(self.selenium, self.timeout).until(lambda s: len(results) > 0)
-        return [self.Result(self.testsetup, result) for result in results]
-
-    class Result(PageRegion):
-
-        _name_locator = (By.CSS_SELECTOR, ".mkt-product-name")
-
-        @property
-        def name(self):
-            return self.find_element(*self._name_locator).text
-
-        def click(self):
-            self.selenium.find_element(*self._name_locator).click()
-            from pages.mobile.details import Details
-            return Details(self.testsetup)

--- a/tests/mobile/test_home_page.py
+++ b/tests/mobile/test_home_page.py
@@ -19,17 +19,19 @@ class TestHomepage():
     def test_that_verifies_categories_menu(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        categories = home_page.more_menu.click_categories()
+        page = home_page.click_apps()
+        categories = page.click_categories()
         assert len(categories.categories) > 0
 
     @pytest.mark.nondestructive
     def test_switch_between_new_and_popular_pages(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
-        popular_apps = home_page.more_menu.click_popular()
-        assert 'Popular' == home_page.feed_title_text
-        assert len(popular_apps) > 0
+        page = home_page.click_apps()
+        page.click_popular()
+        assert page.is_popular_selected
+        assert len(page.items()) > 0
 
-        new_apps = home_page.more_menu.click_new()
-        assert 'New' == home_page.feed_title_text
-        assert len(new_apps) > 0
+        page.click_new()
+        assert page.is_new_selected
+        assert len(page.items()) > 0

--- a/tests/mobile/test_search.py
+++ b/tests/mobile/test_search.py
@@ -14,7 +14,7 @@ class TestSearch():
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
         search_page = home_page.header.search('')
-        assert len(search_page.results()) > 0
+        assert len(search_page.items()) > 0
 
     @pytest.mark.nondestructive
     def test_that_searching_returns_results(self, mozwebqa):
@@ -24,7 +24,7 @@ class TestSearch():
         search_term = details_page.title
         details_page.header.click_back()
         search_page = home_page.header.search(search_term)
-        results = search_page.results()
+        results = search_page.items()
         assert len(results) > 0
         assert search_term in [result.name for result in results]
 


### PR DESCRIPTION
This should allow all current mobile tests to pass, provided we're using Android >= 5.0.

This includes some big changes/refactors so I'd appreciate a close review of the code.

Adhoc running at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/marketplace.mobile.adhoc/40/

@mozilla/web-qa-sorcerers r?