### PR TITLE
Mark the paid app submission test as expected to fail

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -47,10 +47,14 @@ class Page(object):
             self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
 
     def is_element_visible(self, *locator):
+        self.selenium.implicitly_wait(0)
         try:
             return self._selenium_root.find_element(*locator).is_displayed()
         except (NoSuchElementException, ElementNotVisibleException):
             return False
+        finally:
+            # set back to where you once belonged
+            self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
 
     def is_element_not_visible(self, *locator):
         self.selenium.implicitly_wait(0)

--- a/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
+++ b/tests/desktop/developer_hub/test_developer_hub_submit_apps.py
@@ -79,6 +79,7 @@ class TestDeveloperHubSubmitApps(BaseTest):
             delete_popup = edit_app.click_delete_app()
             delete_popup.delete_app()
 
+    @pytest.mark.xfail(reason='https://github.com/mozilla/marketplace-tests/issues/741')
     @pytest.mark.credentials
     def test_hosted_paid_app_submission(self, mozwebqa, login_new):
         if '-dev.allizom' in mozwebqa.base_url:


### PR DESCRIPTION
I've also fixed an issue in `is_element_visible` which would make `wait_for_element_visible` take 10 times longer to fail than it should (because each check was incurring the implicit wait penalty).