### PR TITLE
Wait after clicking tab menu items

### DIFF
--- a/pages/desktop/consumer_pages/home.py
+++ b/pages/desktop/consumer_pages/home.py
@@ -39,9 +39,11 @@ class Home(Base):
         new_tab_menu = self.selenium.find_element(*self._new_tab_menu_locator)
         self.scroll_to_element(new_tab_menu)
         new_tab_menu.click()
+        self.wait_for_element_visible(*self._item_locator)
 
     def click_popular_tab(self):
         self.find_element(*self._popular_tab_menu_locator).click()
+        self.wait_for_element_visible(*self._item_locator)
 
     def click_homepage_tab(self):
         self.find_element(*self._new_tab_menu_locator).click()


### PR DESCRIPTION
`is_element_visible` has recently been changed to not incur any implicit timeout when initially locating the element. Unfortunately, this means that any use of the method that was relying on the additional wait is likely to fail.

Ideally in this particular case, these tab menu methods would return page objects that wait for the page to be ready. We would also ideally use WebDriverWait instead of reimplementing them in the various `wait_for_` methods. Fixing these two things is not a trivial task, so for now adding these two additional waits should be enough to get the tests passing again.