### PR TITLE
Xfail test_that_application_page_contains_proper_objects on dev due to Bug 1242648 - Support info doesn't show up on an empty profile

### DIFF
--- a/tests/desktop/consumer_pages/test_details_page.py
+++ b/tests/desktop/consumer_pages/test_details_page.py
@@ -14,6 +14,9 @@ class TestDetailsPage(BaseTest):
     @pytest.mark.sanity
     @pytest.mark.nondestructive
     def test_that_application_page_contains_proper_objects(self, mozwebqa):
+        if '-dev' in mozwebqa.base_url:
+            pytest.xfail("Bug 1242648 - Support info doesn't show up on an empty profile")
+
         home_page = Home(mozwebqa)
         home_page.go_to_homepage()
         assert home_page.is_the_current_page


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1242648

This addresses the failure being seen on dev [1].

@mozilla/web-qa-sorcerers r?

[1] https://webqa-ci.mozilla.com/view/Marketplace/job/marketplace.dev/557/testReport/test_details_page/TestDetailsPage/test_that_application_page_contains_proper_objects/