### PR TITLE
Fix app title locator in mobile detail page

### DIFF
--- a/pages/mobile/details.py
+++ b/pages/mobile/details.py
@@ -13,7 +13,7 @@ from pages.mobile.base import Base
 
 class Details(Base):
 
-    _title_locator = (By.CSS_SELECTOR, '.mkt-tile .mkt-product-name')
+    _title_locator = (By.CSS_SELECTOR, '.mkt-header--title')
     _write_review_locator = (By.CSS_SELECTOR, '.review-button')
     _view_reviews_locator = (By.CSS_SELECTOR, '.review-buttons li:nth-child(2) .button')
     _product_details_locator = (By.CSS_SELECTOR, '.main.full.app-header.previews-expanded > div')


### PR DESCRIPTION
This is needed due to https://github.com/mozilla/fireplace/commit/022947c98522cd76ca42ec05db4f888d984f213d which caused test_that_searching_returns_results to fail consistently. @krupa r?